### PR TITLE
브라우저 넓이에 따른 분기 처리 및 커서 스토어 최적화

### DIFF
--- a/src/AppDesktop.tsx
+++ b/src/AppDesktop.tsx
@@ -1,33 +1,28 @@
 import React, { useEffect } from "react";
 import "./App.css";
 import Background from "./components/background/Background";
-import { useMousePositionStore } from "./store/useMousePositionStore";
 import { Route, Routes } from "react-router-dom";
-import Home from "./components/Home";
-import { testLogin } from "./api/test";
+import WindowSizeProvider from "./components/utilComponents/WindowSizeProvider";
+import { MousePositonSetter } from "./components/utilComponents/MousePositionSetter";
 
+// Home은 즉시 로드
+import Home from "./components/Home";
 const Modal = React.lazy(() => import("./components/modal/Modal"));
 const Login = React.lazy(() => import("./components/modal/Login"));
 
 export default function AppDesktop() {
-  // 마우스 포지션 스토어에 저장
-  const updateMousePosition = (e: MouseEvent) => {
-    useMousePositionStore.getState().setMousePosition(e.clientX, e.clientY);
-  };
   useEffect(() => {
-    testLogin();
-    window.addEventListener("mousemove", updateMousePosition);
-    window.addEventListener("dragover", updateMousePosition);
-    return () => {
-      window.removeEventListener("mousemove", updateMousePosition);
-      window.removeEventListener("dragover", updateMousePosition);
-    };
-  }, []);
+    // testLogin();
+  });
 
   return (
     <Background>
+      <WindowSizeProvider />
+      <MousePositonSetter />
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/chat/:id" element={<Home />} />
+        <Route path="/chat/new" element={<Home />} />
 
         <Route path="modal" element={<Modal />}>
           <Route path="login" element={<Login />} />

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,5 +1,3 @@
-export default function Home(){
-    return (
-        <></>
-    )
+export default function Home() {
+  return <></>;
 }

--- a/src/components/utilComponents/MousePositionSetter.tsx
+++ b/src/components/utilComponents/MousePositionSetter.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useMousePositionStore } from "../../store/useMousePositionStore";
+
+/**
+ * 마우스 포지션 실시간으로 스토어에 저장해주는 기능성 컴포넌트
+ * requestAnimationFrame으로 성능 개선
+ * @returns {null}
+ */
+export function MousePositonSetter() {
+  let raf = 0;
+  const onMove = (e: MouseEvent) => {
+    if (raf) cancelAnimationFrame(raf);
+    raf = requestAnimationFrame(() => {
+      useMousePositionStore.getState().setMousePosition(e.clientX, e.clientY);
+    });
+  };
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("dragover", onMove);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("dragover", onMove);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/utilComponents/WindowSizeProvider.tsx
+++ b/src/components/utilComponents/WindowSizeProvider.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import { useDeviceTypeStore } from "../../store/useDeviceTypeStore";
+import { useWindowWidthStore } from "../../store/useWindowWidthStore";
+
+const MOBILE_THRESHOLD = 640;
+
+/**
+ * 브라우저 너비 계산 및 저장용 기능성 컴포넌트
+ * @returns {null}
+ */
+export default function WindowSizeProvider() {
+  const setWindowWidth = useWindowWidthStore((s) => s.setWindowWidth);
+  const setPlatform = useDeviceTypeStore((s) => s.setPlatform);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    let prevPlatform = useDeviceTypeStore.getState().platform;
+
+    const handle = () => {
+      const w = window.innerWidth;
+      setWindowWidth(w);
+      const newPlatform = w < MOBILE_THRESHOLD ? "mobile" : "desktop";
+      if (prevPlatform !== newPlatform) {
+        setPlatform(newPlatform);
+        prevPlatform = newPlatform;
+      }
+    };
+
+    handle(); // 초기 실행
+    let raf = 0;
+    const onResize = () => {
+      if (raf) cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(handle);
+    };
+
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [setWindowWidth, setPlatform]);
+
+  return null;
+}

--- a/src/hooks/useDeviceType.tsx
+++ b/src/hooks/useDeviceType.tsx
@@ -1,19 +1,11 @@
-import { useEffect, useState } from "react";
+import { useDeviceTypeStore } from "../store/useDeviceTypeStore";
 
 /**
- *
- * @returns {"mobile" | "desktop"}
  * navigator.userAgent를 사용해 유저의 플랫폼을 불러오고
  * /iphone|ipad|ipod|android|windows phone/ 해당 정규식 패턴 내에 플랫폼이 해당하는지 검사함
  */
-export function useDeviceType(): "mobile" | "desktop" {
-  const [type, setType] = useState<"mobile" | "desktop">("desktop");
-
-  useEffect(() => {
-    const userAgent = navigator.userAgent.toLowerCase();
-    const isMobile = /iphone|ipad|ipod|android|windows phone/g.test(userAgent);
-    setType(isMobile ? "mobile" : "desktop");
-  }, []);
-
-  return type;
+export function useDeviceTypeHook() {
+  const userAgent = navigator.userAgent.toLowerCase();
+  const isMobile = /iphone|ipad|ipod|android|windows phone/g.test(userAgent);
+  useDeviceTypeStore.getState().setPlatform(isMobile ? "mobile" : "desktop");
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,9 @@
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import { BrowserRouter } from "react-router-dom";
-import { useDeviceType } from "./hooks/useDeviceType.tsx";
+import { useDeviceTypeHook } from "./hooks/useDeviceType.tsx";
 import React from "react";
+import { useDeviceTypeStore } from "./store/useDeviceTypeStore.ts";
 
 const AppMobile = React.lazy(() => import("./AppMobile.tsx"));
 const AppDesktop = React.lazy(() => import("./AppDesktop.tsx"));
@@ -14,7 +15,8 @@ createRoot(document.getElementById("root")!).render(
 );
 
 function Root() {
-  const device = useDeviceType();
+  useDeviceTypeHook();
+  const device = useDeviceTypeStore.getState().platform;
   if (device === "mobile") return <AppMobile />;
   return <AppDesktop />;
 }

--- a/src/store/useDeviceTypeStore.ts
+++ b/src/store/useDeviceTypeStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+export type Platform = "mobile" | "desktop";
+
+interface DeviceTypeStore {
+  platform: Platform;
+  setPlatform: (val: Platform) => void;
+}
+
+/**
+ * 디바이스 설정용 스토어
+ * @platform {"mobile" | "desktop"}
+ */
+export const useDeviceTypeStore = create<DeviceTypeStore>((set) => ({
+  platform: "desktop",
+  setPlatform: (val: Platform) => set(() => ({ platform: val })),
+}));

--- a/src/store/useMousePositionStore.ts
+++ b/src/store/useMousePositionStore.ts
@@ -1,11 +1,34 @@
 import { create } from "zustand";
+import { useWindowWidthStore } from "./useWindowWidthStore";
+import { useDeviceTypeStore } from "./useDeviceTypeStore";
 
+/**
+ * x좌표 트리거
+ */
+export type WhereIsMouse = "center" | "left" | "right";
+
+export const triggerDistance = 200;
 interface MousePositionState {
   mousePosition: { x: number | null; y: number | null };
+  whereIsMouse: WhereIsMouse;
   setMousePosition: (x: number | null, y: number | null) => void;
 }
 
+/**
+ * 커서 UI를 사용하는 모든 컴포넌트들을 위한 스토어
+ */
 export const useMousePositionStore = create<MousePositionState>((set) => ({
   mousePosition: { x: null, y: null },
-  setMousePosition: (x, y) => set({ mousePosition: { x, y } }),
+  whereIsMouse: "center",
+  setMousePosition: (x, y) => {
+    let where: WhereIsMouse = "center";
+    const windowWidth = useWindowWidthStore.getState().windowWidth;
+    if (useDeviceTypeStore.getState().platform !== "desktop") return;
+
+    if (x !== null) {
+      if (x < triggerDistance) where = "left";
+      else if (x > windowWidth - triggerDistance) where = "right";
+    }
+    set({ mousePosition: { x, y }, whereIsMouse: where });
+  },
 }));

--- a/src/store/useWindowWidthStore.ts
+++ b/src/store/useWindowWidthStore.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+
+interface WindowWidth {
+  windowWidth: number;
+  setWindowWidth: (w: number) => void;
+}
+
+/**
+ * 브라우저 너비 저장 스토어
+ */
+export const useWindowWidthStore = create<WindowWidth>((set) => ({
+  windowWidth: 0,
+  setWindowWidth: (w) => set({ windowWidth: w }),
+}));


### PR DESCRIPTION
생성
src\components\utilComponents
└MousePositionSetter.tsx
└WindowSizeProvider.tsx
src\store\useDeviceTypeStore.ts
src\store\useWindowWidthStore.ts

변경
src\hooks\useDeviceType.tsx
src\store\useMousePositionStore.ts
src\AppDesktop.tsx
src\main.tsx

커서 및 브라우저 너비 스토어와 저장 컴포넌트 최적화 진행했습니다
너비 640px 미만일 경우 모바일 화면으로 전환되도록 만들었습니다
스토어의 경우 데스크탑 환경이 아닐경우 x, y 좌표 저장 자체가 안되도록 만들었습니다(이후 변경될수도 있습니다)