### PR TITLE
#9 feat : 사이드바, 채팅 화면 커서위치에 따른 반응 적용

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,3 +1,13 @@
+import { Chat } from "./chat/Chat";
+import { Leftbar } from "./sidebar/leftbar";
+import { Rightbar } from "./sidebar/rightbar";
+
 export default function Home() {
-  return <></>;
+  return (
+    <>
+      <Leftbar />
+      <Rightbar />
+      <Chat />
+    </>
+  );
 }

--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -1,0 +1,11 @@
+import { ChatPosition } from "./ChatPosition";
+
+
+export function Chat() {
+
+  return (
+    <ChatPosition>
+      <div className="chatbox"></div>
+    </ChatPosition>
+  );
+}

--- a/src/components/chat/ChatPosition.tsx
+++ b/src/components/chat/ChatPosition.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import {
+  barMargin,
+  useMousePositionStore,
+} from "../../store/useMousePositionStore";
+import { motion } from "framer-motion";
+
+
+
+export function ChatPosition({ children }: { children: React.ReactNode }) {
+  const { whereIsMouse } = useMousePositionStore();
+
+  const chatX = useMemo(() => {
+    const positions = {
+      center: 0,
+      left: barMargin,
+      right: -barMargin,
+    };
+    return positions[whereIsMouse] ?? 0;
+  }, [whereIsMouse]);
+
+  return (
+    <motion.div
+      initial={{ x: 0 }}
+      animate={{
+        x: chatX,
+      }}
+      transition={{ type: "spring", stiffness: 300, damping: 30 }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/chat/ChatPosition.tsx
+++ b/src/components/chat/ChatPosition.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import {
-  barMargin,
+  BAR_MARGIN,
   useMousePositionStore,
 } from "../../store/useMousePositionStore";
 import { motion } from "framer-motion";
@@ -13,8 +13,8 @@ export function ChatPosition({ children }: { children: React.ReactNode }) {
   const chatX = useMemo(() => {
     const positions = {
       center: 0,
-      left: barMargin,
-      right: -barMargin,
+      left: BAR_MARGIN,
+      right: -BAR_MARGIN,
     };
     return positions[whereIsMouse] ?? 0;
   }, [whereIsMouse]);

--- a/src/components/sidebar/Leftbar.tsx
+++ b/src/components/sidebar/Leftbar.tsx
@@ -1,0 +1,9 @@
+import { LeftbarPosition } from "./LeftbarPosition";
+
+export function Leftbar() {
+  return (
+    <LeftbarPosition>
+      <div className="leftbar"></div>
+    </LeftbarPosition>
+  );
+}

--- a/src/components/sidebar/LeftbarPosition.tsx
+++ b/src/components/sidebar/LeftbarPosition.tsx
@@ -1,0 +1,21 @@
+import {
+  barMargin,
+  triggerDistance,
+  useMousePositionStore,
+} from "../../store/useMousePositionStore";
+import { motion } from "framer-motion";
+
+export function LeftbarPosition({ children }: { children: React.ReactNode }) {
+  const { whereIsMouse } = useMousePositionStore();
+  return (
+    <motion.div
+      initial={{ x: -triggerDistance }}
+      animate={{
+        x: whereIsMouse === "left" ? barMargin : -triggerDistance,
+      }}
+      transition={{ type: "spring", stiffness: 300, damping: 30 }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/sidebar/LeftbarPosition.tsx
+++ b/src/components/sidebar/LeftbarPosition.tsx
@@ -1,6 +1,6 @@
 import {
-  barMargin,
-  triggerDistance,
+  BAR_MARGIN,
+  TRIGGER_DISTANCE,
   useMousePositionStore,
 } from "../../store/useMousePositionStore";
 import { motion } from "framer-motion";
@@ -9,9 +9,9 @@ export function LeftbarPosition({ children }: { children: React.ReactNode }) {
   const { whereIsMouse } = useMousePositionStore();
   return (
     <motion.div
-      initial={{ x: -triggerDistance }}
+      initial={{ x: -TRIGGER_DISTANCE }}
       animate={{
-        x: whereIsMouse === "left" ? barMargin : -triggerDistance,
+        x: whereIsMouse === "left" ? BAR_MARGIN : -TRIGGER_DISTANCE,
       }}
       transition={{ type: "spring", stiffness: 300, damping: 30 }}
     >

--- a/src/components/sidebar/Rightbar.tsx
+++ b/src/components/sidebar/Rightbar.tsx
@@ -1,0 +1,9 @@
+import { RightbarPosition } from "./RightbarPosition";
+
+export function Rightbar() {
+  return (
+    <RightbarPosition>
+      <div className="rightbar"></div>
+    </RightbarPosition>
+  );
+}

--- a/src/components/sidebar/RightbarPosition.tsx
+++ b/src/components/sidebar/RightbarPosition.tsx
@@ -1,0 +1,21 @@
+import {
+  barMargin,
+  triggerDistance,
+  useMousePositionStore,
+} from "../../store/useMousePositionStore";
+import { motion } from "framer-motion";
+
+export function RightbarPosition({ children }: { children: React.ReactNode }) {
+  const { whereIsMouse } = useMousePositionStore();
+  return (
+    <motion.div
+      initial={{ x: triggerDistance }}
+      animate={{
+        x: whereIsMouse === "right" ? -barMargin : triggerDistance,
+      }}
+      transition={{ type: "spring", stiffness: 300, damping: 30 }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/sidebar/RightbarPosition.tsx
+++ b/src/components/sidebar/RightbarPosition.tsx
@@ -1,6 +1,6 @@
 import {
-  barMargin,
-  triggerDistance,
+  BAR_MARGIN,
+  TRIGGER_DISTANCE,
   useMousePositionStore,
 } from "../../store/useMousePositionStore";
 import { motion } from "framer-motion";
@@ -9,9 +9,9 @@ export function RightbarPosition({ children }: { children: React.ReactNode }) {
   const { whereIsMouse } = useMousePositionStore();
   return (
     <motion.div
-      initial={{ x: triggerDistance }}
+      initial={{ x: TRIGGER_DISTANCE }}
       animate={{
-        x: whereIsMouse === "right" ? -barMargin : triggerDistance,
+        x: whereIsMouse === "right" ? -BAR_MARGIN : TRIGGER_DISTANCE,
       }}
       transition={{ type: "spring", stiffness: 300, damping: 30 }}
     >

--- a/src/store/useMousePositionStore.ts
+++ b/src/store/useMousePositionStore.ts
@@ -8,6 +8,7 @@ import { useDeviceTypeStore } from "./useDeviceTypeStore";
 export type WhereIsMouse = "center" | "left" | "right";
 
 export const triggerDistance = 200;
+export const barMargin = 50;
 interface MousePositionState {
   mousePosition: { x: number | null; y: number | null };
   whereIsMouse: WhereIsMouse;

--- a/src/store/useMousePositionStore.ts
+++ b/src/store/useMousePositionStore.ts
@@ -7,8 +7,8 @@ import { useDeviceTypeStore } from "./useDeviceTypeStore";
  */
 export type WhereIsMouse = "center" | "left" | "right";
 
-export const triggerDistance = 200;
-export const barMargin = 50;
+export const TRIGGER_DISTANCE = 200;
+export const BAR_MARGIN = 50;
 interface MousePositionState {
   mousePosition: { x: number | null; y: number | null };
   whereIsMouse: WhereIsMouse;
@@ -27,8 +27,8 @@ export const useMousePositionStore = create<MousePositionState>((set) => ({
     if (useDeviceTypeStore.getState().platform !== "desktop") return;
 
     if (x !== null) {
-      if (x < triggerDistance) where = "left";
-      else if (x > windowWidth - triggerDistance) where = "right";
+      if (x < TRIGGER_DISTANCE) where = "left";
+      else if (x > windowWidth - TRIGGER_DISTANCE) where = "right";
     }
     set({ mousePosition: { x, y }, whereIsMouse: where });
   },


### PR DESCRIPTION
framer-motion 라이브러리의 motion.div 적용하여 커서의 위치에 따라 변하는 상태값을 기준으로 각각의 컴포넌트(사이드바 2개, 채팅화면)에서 x좌표값을 수정함. 
각 동작마다 motion.div의 animate, transition를 이용해서 위치와 애니메이션을 적용함. 
움직이는 정도는 src\store\useMousePositionStore.ts에 상수 TRIGGER_DISTANCE 와 BAR_MARGIN을 통해 각각 200, 50으로 선언해놓았음.