### PR TITLE
#1 feat: 이용약관 모달 추가 및 toast 알림 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "lodash": "^4.17.21",
         "react-day-picker": "^9.11.0",
         "react-icons": "^5.5.0",
+        "react-toastify": "^11.0.5",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.1",
         "vite": "^7.1.2",
@@ -2135,6 +2136,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3684,6 +3695,20 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lodash": "^4.17.21",
     "react-day-picker": "^9.11.0",
     "react-icons": "^5.5.0",
+    "react-toastify": "^11.0.5",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,16 @@ import Background from "./components/background/Background";
 import { Route, Routes } from "react-router-dom";
 import WindowSizeProvider from "./components/utilComponents/WindowSizeProvider";
 import { MousePositonSetter } from "./components/utilComponents/MousePositionSetter";
+import { ToastContainer } from "react-toastify";
+
 
 // Home은 즉시 로드
 import Home from "./components/Home";
+
 const Modal = React.lazy(() => import("./components/modal/Modal"));
 const AuthModal = React.lazy(() => import("./components/modal/authmodal/AuthModal"));
 const ScheduleModal = React.lazy(() => import("./components/modal/schedule_modal/scheduleModal"));
+const TermsModal = React.lazy(() => import("./components/modal/authmodal/TermsModal"));
 
 export default function AppDesktop() {
   useEffect(() => {
@@ -17,19 +21,37 @@ export default function AppDesktop() {
   });
 
   return (
-    <Background>
-      <WindowSizeProvider />
-      <MousePositonSetter />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/chat/:id" element={<Home />} />
-        <Route path="/chat/new" element={<Home />} />
+    <>
+        <Background>
+          <WindowSizeProvider />
+          <MousePositonSetter />
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/chat/:id" element={<Home />} />
+            <Route path="/chat/new" element={<Home />} />
 
-          <Route path="modal" element={<Modal />}>
-            <Route path="auth" element={<AuthModal />} />
-            <Route path="schedule" element={<ScheduleModal />} />
-          </Route>
-        </Routes>
-    </Background>
+              <Route path="modal" element={<Modal />}>
+                <Route path="auth" element={<AuthModal />} />
+                <Route path="terms" element={<TermsModal />} />
+                <Route path="schedule" element={<ScheduleModal />} />
+              </Route>
+            </Routes>
+        </Background>
+
+        <ToastContainer
+              position="top-center"  // 위치
+              autoClose={3000}       // 3초 후 닫힘
+              hideProgressBar        // 프로그레스바 표시 여부
+              newestOnTop
+              closeOnClick
+              rtl={false}
+              pauseOnFocusLoss
+              draggable
+              pauseOnHover
+              theme="light"
+              style={{ zIndex: 9999 }} // 모달보다 높게 지정
+            />
+    
+    </>
   );
 }

--- a/src/AppMobile.tsx
+++ b/src/AppMobile.tsx
@@ -5,7 +5,7 @@ import { Route, Routes } from "react-router-dom";
 import Home from "./components/Home";
 
 const Modal = React.lazy(() => import("./components/modal/Modal"));
-const Login = React.lazy(() => import("./components/modal/Login"));
+const Login = React.lazy(() => import("./components/modal/authmodal/LoginForm"));
 
 // 단순 분기 처리만 한 상태
 // 반드시 앱 데스크탑 파일을 참조하여 작성할것!!

--- a/src/api/dummyData/schedule.ts
+++ b/src/api/dummyData/schedule.ts
@@ -2,7 +2,7 @@ import type { Schedule } from '../../components/modal/schedule_modal/types/sched
 import { combineDateAndTime } from '../../utils/time';
 
 // 더미 데이터
-let dummySchedules: Schedule[] = [
+export let dummySchedules: Schedule[] = [
   {
     id: 1,
     title: '팀 미팅',

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -13,7 +13,6 @@ type Props = {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   error: string;
   leftIcon?: React.ReactNode;
-  passwordToggle?: boolean;
 };
 
 export const InputField = ({
@@ -24,10 +23,9 @@ export const InputField = ({
   onChange,
   error,
   leftIcon,
-  passwordToggle,
 }: Props) => {
   const [show, setShow] = useState(false);
-  const actualType = passwordToggle ? (show ? 'text' : 'password') : type;
+  const actualType = type === 'password' ? (show ? 'text' : 'password') : type;
  const { inputBorder, tabBtnText, deleteBtnBg } = useThemeColors()
 
   const wrapperStyle = css`
@@ -76,8 +74,12 @@ export const InputField = ({
           value={value}
           onChange={onChange}
         />
-        {passwordToggle && (
-          <button type="button" css={toggleButtonStyle} onClick={() => setShow(!show)}>
+        {type === 'password' && (
+          <button
+            type="button"
+            css={toggleButtonStyle}
+            onClick={() => setShow(!show)}
+          >
             {show ? <IoEyeOutline /> : <FaRegEyeSlash />}
           </button>
         )}

--- a/src/components/modal/authmodal/LoginForm.tsx
+++ b/src/components/modal/authmodal/LoginForm.tsx
@@ -75,11 +75,12 @@ export default function LoginForm() {
   };
 
   return (
-    <form css={formStyle} onSubmit={handleSubmit}>
+    <form css={formStyle}>
       <div>
         <div>
           <label htmlFor="login-email" css={labelStyle}>이메일</label>
           <InputField
+            type="text"
             name="login-email"
             placeholder="your@email.com"
             value={form.email}
@@ -95,18 +96,18 @@ export default function LoginForm() {
             <p>비밀번호 찾기</p>
           </div>
           <InputField
+            type="password"
             name="login-password"
             placeholder="비밀번호를 입력하세요"
             value={form.password}
             onChange={(e) => setForm({...form, password:e.target.value})}
             leftIcon={<FaLock />}
-            passwordToggle
             error={errors.password}
           />
         </div>
       </div>
 
-      <button type="submit" css={buttonStyle}>
+      <button type="button" onClick={handleSubmit} css={buttonStyle}>
         로그인
       </button>
     </form>

--- a/src/components/modal/authmodal/SignupForm.tsx
+++ b/src/components/modal/authmodal/SignupForm.tsx
@@ -10,8 +10,11 @@ import {
   validateName,
   validatePassword,
 } from "../../../utils/validator";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 
 export default function SignupForm() {
+  const navigate = useNavigate();
   const [form, setForm] = useState({
     name: "",
     email: "",
@@ -86,10 +89,16 @@ export default function SignupForm() {
 
     setErrors(newErrors);
 
-    // 에러 없으면 로그인 로직 진행
-    if (!emailError && !passwordError) {
+    // 에러 없으면 회원가입 로직 진행
+    if (!nameError && !emailError && !passwordError && !confirmPasswordError) {
+      // 약관 동의 체크
+      if (!form.agreeTerms) {
+        toast.error("이용약관 및 개인정보 처리방침에 동의해야 회원가입이 가능합니다.");
+        return;
+      }
       console.log("회원가입 시도:", { form });
-    }
+      // TODO: 실제 회원가입 API 호출
+  }
   };
 
   return (
@@ -159,12 +168,16 @@ export default function SignupForm() {
 
       <label css={agree}>
         <input
+          id="agreeTerms"
           type="checkbox"
           checked={form.agreeTerms}
           onChange={(e) => setForm({ ...form, agreeTerms: e.target.checked })}
         />
         이용약관 및 개인정보처리방침에 동의합니다
-        <a href="#">자세히 보기</a>
+        <a href="#" onClick={(e) => {
+          e.preventDefault();
+          navigate("/modal/terms"); // 약관 모달로 이동
+        }}>자세히 보기</a>
       </label>
 
       <button type="submit" css={submit}>

--- a/src/components/modal/authmodal/SignupForm.tsx
+++ b/src/components/modal/authmodal/SignupForm.tsx
@@ -2,7 +2,7 @@
 import { css } from "@emotion/react";
 import { useState } from "react";
 import { FaUser, FaEnvelope, FaLock } from "react-icons/fa";
-import { InputField } from "../../InputField"; // 경로 확인 필요
+import { InputField } from "../../InputField";
 import { useThemeColors } from "../../../hooks/useThemeColors";
 import {
   validateConfirmPassword,
@@ -23,7 +23,7 @@ export default function SignupForm() {
     agreeTerms: false,
   });
 
-  // 에러 상태 (추후 유효성 검사 시 활용 가능)
+  // 에러 상태
   const [errors, setErrors] = useState({
     name: "",
     email: "",
@@ -92,22 +92,24 @@ export default function SignupForm() {
     // 에러 없으면 회원가입 로직 진행
     if (!nameError && !emailError && !passwordError && !confirmPasswordError) {
       // 약관 동의 체크
+      // 어느 시점에서 해야하면 좋을 지 모르겠음
       if (!form.agreeTerms) {
         toast.error("이용약관 및 개인정보 처리방침에 동의해야 회원가입이 가능합니다.");
         return;
       }
-      console.log("회원가입 시도:", { form });
+      toast.success("회원가입 요청을 보냈습니다!");
       // TODO: 실제 회원가입 API 호출
   }
   };
 
   return (
-    <form noValidate css={formStyle} onSubmit={handleSubmit}>
+    <form noValidate css={formStyle}>
       <div>
         <label htmlFor="signup-name" css={labelStyle}>
           이름
         </label>
         <InputField
+          type="text"
           name="signup-name"
           placeholder="홍길동"
           value={form.name}
@@ -143,7 +145,6 @@ export default function SignupForm() {
           value={form.password}
           onChange={(e) => setForm({ ...form, password: e.target.value })}
           leftIcon={<FaLock />}
-          passwordToggle
           error={errors.password}
         />
       </div>
@@ -161,7 +162,6 @@ export default function SignupForm() {
             setForm({ ...form, confirmPassword: e.target.value })
           }
           leftIcon={<FaLock />}
-          passwordToggle
           error={errors.confirmPassword}
         />
       </div>
@@ -180,7 +180,7 @@ export default function SignupForm() {
         }}>자세히 보기</a>
       </label>
 
-      <button type="submit" css={submit}>
+      <button type="button" onClick={handleSubmit} css={submit}>
         회원가입
       </button>
     </form>

--- a/src/components/modal/authmodal/TermsModal.tsx
+++ b/src/components/modal/authmodal/TermsModal.tsx
@@ -1,9 +1,12 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import { useNavigate } from "react-router-dom";
+import { useThemeColors } from "../../../hooks/useThemeColors";
 
 export default function TermsModal() {
   const navigate = useNavigate();
+
+  const { modalBackground, addButtonBg} = useThemeColors();
 
   const overlay = css`
     position: fixed;
@@ -19,7 +22,7 @@ export default function TermsModal() {
   `;
 
   const modal = css`
-    background: #fff;
+    background: ${modalBackground};
     padding: 24px;
     border-radius: 12px;
     width: 500px;
@@ -30,8 +33,8 @@ export default function TermsModal() {
     margin-top: 16px;
     padding: 8px 12px;
     border-radius: 6px;
-    background: #333;
-    color: #fff;
+    background: ${addButtonBg};
+    color: ${modalBackground};
     cursor: pointer;
   `;
 

--- a/src/components/modal/authmodal/TermsModal.tsx
+++ b/src/components/modal/authmodal/TermsModal.tsx
@@ -1,0 +1,117 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useNavigate } from "react-router-dom";
+
+export default function TermsModal() {
+  const navigate = useNavigate();
+
+  const overlay = css`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  `;
+
+  const modal = css`
+    background: #fff;
+    padding: 24px;
+    border-radius: 12px;
+    width: 500px;
+    max-height: 80vh;
+  `;
+
+  const closeBtn = css`
+    margin-top: 16px;
+    padding: 8px 12px;
+    border-radius: 6px;
+    background: #333;
+    color: #fff;
+    cursor: pointer;
+  `;
+
+  const title = css`
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 16px;
+  `;
+
+  const content = css`
+    font-size: 14px;
+    line-height: 1.6;
+    max-height: 60vh;
+    overflow-y: auto;
+    padding-right: 8px;
+  `;
+
+  return (
+    <div css={overlay}>
+        <div css={modal}>
+
+
+
+      <h2 css={title}>이용약관 및 개인정보 처리방침</h2>
+      <div css={content}>
+        <p>
+          본 약관은 <strong>[서비스 이름]</strong> (이하 "회사")가 제공하는
+          모든 서비스의 이용과 관련하여 회사와 이용자 간의 권리, 의무 및
+          책임사항을 규정함을 목적으로 합니다.
+        </p>
+
+        <h3>1. 약관 동의</h3>
+        <p>
+          회원은 본 약관에 동의함으로써 서비스를 이용할 수 있으며, 동의하지
+          않을 경우 서비스 이용이 제한될 수 있습니다.
+        </p>
+
+        <h3>2. 서비스 이용</h3>
+        <p>
+          1) 서비스 이용은 관련 법령 및 회사 정책을 준수해야 합니다.
+          <br />
+          2) 회사는 시스템 점검 등으로 인해 일시적으로 서비스를 중단할 수
+          있습니다.
+        </p>
+
+        <h3>3. 개인정보 수집 및 이용</h3>
+        <p>
+          회사는 회원가입 및 서비스 제공을 위해 최소한의 개인정보를 수집합니다.
+          <br />
+          수집 항목: 이름, 이메일, 비밀번호
+          <br />
+          수집 목적: 회원관리, 서비스 제공, 고객 문의 대응
+        </p>
+
+        <h3>4. 이용제한</h3>
+        <p>
+          회원이 다음 행위를 하는 경우 회사는 서비스 이용을 제한하거나 계정을
+          삭제할 수 있습니다.
+          <br />- 타인의 정보를 도용한 경우
+          <br />- 불법 콘텐츠를 게시하거나 전송한 경우
+          <br />- 서비스 운영을 방해한 경우
+        </p>
+
+        <h3>5. 책임 제한</h3>
+        <p>
+          회사는 천재지변, 불가항력적인 사유로 인한 서비스 장애에 대해서는
+          책임을 지지 않습니다.
+        </p>
+
+        <h3>6. 약관 변경</h3>
+        <p>
+          회사는 필요 시 본 약관을 변경할 수 있으며, 변경 사항은 서비스 내
+          공지사항 등을 통해 안내합니다.
+        </p>
+      </div>
+
+      <button css={closeBtn} onClick={() => navigate("/modal/auth")}>
+        뒤로가기
+      </button>
+        </div>
+    </div>
+  );
+}

--- a/src/styles/mixins.ts
+++ b/src/styles/mixins.ts
@@ -12,6 +12,7 @@ export const overlay = css`
   position: fixed;
   inset: 0;
   backdrop-filter: blur(8px);
+  z-index: 1000; // 모달이 토스트 메시지보다 아래로 오게 z-index 설정
 `;
 
 export const flexWrap = (


### PR DESCRIPTION
- 이용약관 모달 구현
- '자세히 보기' 클릭 시 이용약관 모달로 이동
- 이용약관 동의하지 않으면 toast 알림 표시

미구현
- 뒤로가기 시 입력 폼 상태 유지
<img width="531" height="914" alt="스크린샷 2025-09-24 오후 6 38 49" src="https://github.com/user-attachments/assets/b9e4e1c4-bfe6-446b-934f-87282c04ad2d" />
<img width="523" height="679" alt="스크린샷 2025-09-24 오후 4 43 36" src="https://github.com/user-attachments/assets/47acd148-5fe8-4c00-9f14-82102b211cc5" />
