### PR TITLE
Feature/rightbar api connect

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -143,7 +143,7 @@ class ApiClient {
   }
 }
 
-const BASE_URL = "http://localhost:8080";
+const BASE_URL = "http://oz-digital-human-env.eba-dipavmms.ap-northeast-2.elasticbeanstalk.com/";
 
 const apiClient = new ApiClient(BASE_URL);
 

--- a/src/api/auth/login.ts
+++ b/src/api/auth/login.ts
@@ -1,6 +1,6 @@
 import { handleApiCall, TokenManager } from "../apiClient";
 
-interface LoginReq {
+export type LoginReq ={
   email: string;
   password: string;
 }

--- a/src/api/auth/signup.ts
+++ b/src/api/auth/signup.ts
@@ -1,13 +1,12 @@
 import { handleApiCall } from "../apiClient";
 
-interface Req {
+export type SignupReq ={
   email: string;
   password: string;
   nickname: string;
-  enable_2fa: string;
 }
 
-interface Res {
+export type SignupRes ={
   detail: string;
   user_id: number;
   email: string;
@@ -18,10 +17,10 @@ export const signupApi = {
   POST: {
     /**
      * 회원가입 메서드
-     * @param {Req} payload  이메일, 비번, 닉네임
-     * @returns {Promise<Res>} .detail에 "회원가입이 성공적으로 완료되었습니다." 반환됨
+     * @param {SignupReq} payload  이메일, 비번, 닉네임
+     * @returns {Promise<SignupRes>} .detail에 "회원가입이 성공적으로 완료되었습니다." 반환됨
      */
-    signup: async (payload: Req): Promise<Res> => {
+    signup: async (payload: SignupReq): Promise<SignupRes> => {
       const url = `/api/v1/auth/signup/`;
       return await handleApiCall({ method: "POST", url: url, data: payload });
     },

--- a/src/components/chat/ChatPosition.tsx
+++ b/src/components/chat/ChatPosition.tsx
@@ -11,8 +11,10 @@ const centerPosition = css`
   position: fixed;
   top: 50%;
   left: 50%;
+  pointer-events: none;
   .inner_div{
     transform: translate(-50%, -50%);
+    pointer-events: "auto";
   }
 `;
 

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import ReactDOM from "react-dom";
 import useModal from "../../hooks/useModal";
 import { useEffect } from "react";
@@ -9,22 +9,39 @@ import { modalVariants } from "../../styles/modal/modalVariants";
 import { IoArrowBack } from "react-icons/io5";
 import { css } from "@emotion/react";
 import { useThemeColors } from "../../hooks/useThemeColors";
+import { storeSignupForm } from "../../store/storeSignupForm";
 
 export default function Modal() {
   const navigate = useNavigate();
+  const location = useLocation();
+  // modal로 이동시 이전 경로 저장을 위해 반드시 state: { prevPath: location.pathname } 를 포함 할 것
+  // @example
+  // navi("/modal/auth", {
+  // state: { prevPath: location.pathname }
+  // });
+  const prevPath = location.state?.prevPath || "/";
+  const { resetSignupForm } = storeSignupForm();
   const { isOpen, openModal, closeModal } = useModal();
+
   useEffect(() => {
     openModal();
     return () => closeModal();
   }, [openModal, closeModal]);
 
+  // TODO : 모달창 띄우고 뒤로가기 누를시 이전 화면이 제대로 표시되지 않는 문제가 있음
   const handleClose = () => {
     closeModal();
-    window.history.length > 1 ? navigate(-1) : navigate("/", { replace: true });
+    window.history.length > 1
+      ? navigate(prevPath, { replace: true })
+      : navigate("/", { replace: true });
+    console.log(prevPath);
+
+    resetSignupForm();
   };
+
   const { text } = useThemeColors();
   const backBtnColor = css`
-    border-color: ${text};
+    color: ${text};
   `;
 
   return ReactDOM.createPortal(
@@ -42,14 +59,19 @@ export default function Modal() {
         >
           <motion.div
             key="modal"
+            css={positionCss}
             onClick={(e) => e.stopPropagation()}
             initial={{ scale: 0.9, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}
             transition={{ type: "spring", stiffness: 300, damping: 25 }}
           >
-            <IoArrowBack css={[closeButtonStyle, backBtnColor]} onClick={handleClose} />
             <Outlet />
+            <IoArrowBack
+              className="IoArrowBack"
+              css={[closeButtonStyle, backBtnColor]}
+              onClick={handleClose}
+            />
           </motion.div>
         </motion.div>
       )}
@@ -58,8 +80,14 @@ export default function Modal() {
   );
 }
 
+const positionCss = css`
+  position: relative;
+`;
+
 const closeButtonStyle = css`
   position: absolute;
-  left: -2rem;
+  left: -2.5rem;
   top: 1rem;
+  cursor: pointer;
+  font-size: 1.7rem;
 `;

--- a/src/components/modal/authmodal/AuthModal.tsx
+++ b/src/components/modal/authmodal/AuthModal.tsx
@@ -1,10 +1,11 @@
 /** @jsxImportSource @emotion/react */
-import { useState } from "react";
+import { useEffect,  useRef, useState } from "react";
 import { css } from "@emotion/react";
 import AuthTabs from "./AuthTabs";
 import LoginForm from "./LoginForm";
-import Signupform from "./SignupForm"
+import Signupform from "./SignupForm";
 import SocialLogin from "./SocialLogin";
+import { AnimatePresence, motion } from "framer-motion";
 
 import { IoShieldOutline } from "react-icons/io5";
 import { useThemeColors } from "../../../hooks/useThemeColors";
@@ -14,61 +15,106 @@ export default function AuthModalContent() {
 
   const { modalBackground, descriptionText } = useThemeColors();
 
+  const [height, setHeight] = useState<number | "auto">("auto");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+useEffect(() => {
+  if (!containerRef.current) return;
+
+  const observer = new ResizeObserver((entries) => {
+    for (let entry of entries) {
+      setHeight(entry.contentRect.height + 370);
+    }
+  });
+
+  observer.observe(containerRef.current);
+
+  return () => observer.disconnect();
+}, []);
+
+
   const container = css`
-  width: 400px;
-  background: ${modalBackground};
-  border-radius: 12px;
-  padding: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-`;
+    width: 400px;
+    background: ${modalBackground};
+    border-radius: 12px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  `;
 
-const title = css`
-  display: flex;
-  align-items: center;
-  gap: 5px;
-`
-const header = css`
-  display: flex;
-  justify-content: space-between;
-  
-  text-align: center;
-  h2 {
-    margin: 8px 0 4px;
-    font-size: 20px;
-    font-weight: 700;
-  }
-`;
+  const title = css`
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  `;
+  const header = css`
+    display: flex;
+    justify-content: space-between;
 
-const description = css`
-  font-size: 12px;
-  color: ${descriptionText};
-`
+    text-align: center;
+    h2 {
+      margin: 8px 0 4px;
+      font-size: 20px;
+      font-weight: 700;
+    }
+  `;
 
+  const description = css`
+    font-size: 12px;
+    color: ${descriptionText};
+  `;
 
   return (
-    <div css={container}>
+    <motion.div
+      css={container}
+      animate={{ height }}
+      transition={{ type: "spring", stiffness: 120, damping: 20 }}
+      style={{ overflow: "hidden" }}
+    >
       {/* 상단 로고/타이틀 */}
       <div>
         <div css={header}>
           <div css={title}>
-            <IoShieldOutline size={20}/>
-            <h2>비서 AI</h2> 
+            <IoShieldOutline size={20} />
+            <h2>비서 AI</h2>
           </div>
         </div>
-          <p css={description}>AI 가상비서 서비스에 오신 것을 환영합니다</p>
+        <p css={description}>AI 가상비서 서비스에 오신 것을 환영합니다</p>
       </div>
 
       {/* 로그인/회원가입 탭 */}
       <AuthTabs tab={tab} setTab={setTab} />
 
       {/* 탭에 따른 폼 */}
-      {tab === "login" ? <LoginForm /> : <Signupform/>}
+      <div ref={containerRef}>
+        <AnimatePresence mode="wait">
+          {tab === "login" ? (
+            <motion.div
+              key="login"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <LoginForm />
+            </motion.div>
+          ) : (
+            <motion.div
+              key="register"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.3 }}
+            >
+              <Signupform />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
 
       {/* 간편 로그인 */}
       <SocialLogin />
-    </div>
+    </motion.div>
   );
 }
-

--- a/src/components/modal/authmodal/AuthModal.tsx
+++ b/src/components/modal/authmodal/AuthModal.tsx
@@ -1,22 +1,38 @@
 /** @jsxImportSource @emotion/react */
 import { useEffect,  useRef, useState } from "react";
 import { css } from "@emotion/react";
-import AuthTabs from "./AuthTabs";
+import AuthTabs, { type tab } from "./AuthTabs";
 import LoginForm from "./LoginForm";
 import Signupform from "./SignupForm";
 import SocialLogin from "./SocialLogin";
 import { AnimatePresence, motion } from "framer-motion";
+import { useSearchParams } from "react-router-dom";
 
 import { IoShieldOutline } from "react-icons/io5";
 import { useThemeColors } from "../../../hooks/useThemeColors";
 
+
 export default function AuthModalContent() {
-  const [tab, setTab] = useState<"login" | "register">("login");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentTab = searchParams.get("tab") as tab | null;
+  const [tab, setTab] = useState<tab>(currentTab ?? "login");
 
   const { modalBackground, descriptionText } = useThemeColors();
+  
 
   const [height, setHeight] = useState<number | "auto">("auto");
   const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+  if (currentTab && currentTab !== tab) {
+    setTab(currentTab);
+  }
+}, [currentTab]);
+
+const handleChangeTab = (value:tab) => {
+  setTab(value);
+  setSearchParams({ tab: value });
+};
 
 useEffect(() => {
   if (!containerRef.current) return;
@@ -29,7 +45,7 @@ useEffect(() => {
 
   observer.observe(containerRef.current);
 
-  return () => observer.disconnect();
+  return () => observer.disconnect();;
 }, []);
 
 
@@ -84,7 +100,7 @@ useEffect(() => {
       </div>
 
       {/* 로그인/회원가입 탭 */}
-      <AuthTabs tab={tab} setTab={setTab} />
+      <AuthTabs tab={tab} setTab={handleChangeTab} />
 
       {/* 탭에 따른 폼 */}
       <div ref={containerRef}>

--- a/src/components/modal/authmodal/AuthModal.tsx
+++ b/src/components/modal/authmodal/AuthModal.tsx
@@ -95,7 +95,7 @@ useEffect(() => {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              transition={{ duration: 0.3 }}
+              transition={{ duration: 0.25 }}
             >
               <LoginForm />
             </motion.div>
@@ -105,7 +105,7 @@ useEffect(() => {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              transition={{ duration: 0.3 }}
+              transition={{ duration: 0.25 }}
             >
               <Signupform />
             </motion.div>

--- a/src/components/modal/authmodal/AuthTabs.tsx
+++ b/src/components/modal/authmodal/AuthTabs.tsx
@@ -2,8 +2,10 @@
 import { css } from "@emotion/react";
 import { useThemeColors } from "../../../hooks/useThemeColors";
 
+
+export type tab = "login" | "register";
 interface Props {
-  tab: "login" | "register";
+  tab: tab;
   setTab: (tab: "login" | "register") => void;
 }
 

--- a/src/components/modal/authmodal/LoginForm.tsx
+++ b/src/components/modal/authmodal/LoginForm.tsx
@@ -5,11 +5,11 @@ import { InputField } from "../../InputField";
 import { FaEnvelope, FaLock } from "react-icons/fa";
 import { useThemeColors } from "../../../hooks/useThemeColors";
 import { validateEmail, validatePassword } from "../../../utils/validator";
+import { loginApi, type LoginReq } from "../../../api/auth/login";
+import { toast } from "react-toastify";
 
 export default function LoginForm() {
-
-  const [form, setForm] = useState({ email: "", password: "" });
-
+  const [form, setForm] = useState<LoginReq>({ email: "", password: "" });
 
   const [errors, setErrors] = useState({
     email: "",
@@ -57,7 +57,7 @@ export default function LoginForm() {
     }
   `;
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     const emailError = validateEmail(form.email);
@@ -70,9 +70,16 @@ export default function LoginForm() {
 
     setErrors(newErrors);
 
+    console.log(form);
+
     // 에러 없으면 로그인 로직 진행
     if (!emailError && !passwordError) {
-      console.log("로그인 시도:", { form });
+      try {
+        const res = await loginApi.POST.login(form);
+        toast.success(res.detail);
+      } catch (e) {
+        toast.error(`로그인 에러 발생 : ${e}`);
+      }
     }
   };
 

--- a/src/components/modal/authmodal/SignupForm.tsx
+++ b/src/components/modal/authmodal/SignupForm.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-import { useState } from "react";
+import {  useState } from "react";
 import { FaUser, FaEnvelope, FaLock } from "react-icons/fa";
 import { InputField } from "../../InputField";
 import { useThemeColors } from "../../../hooks/useThemeColors";
@@ -12,17 +12,12 @@ import {
 } from "../../../utils/validator";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
+import { signupApi, type SignupReq } from "../../../api/auth/signup";
+import { storeSignupForm } from "../../../store/storeSignupForm";
 
 export default function SignupForm() {
   const navigate = useNavigate();
-  const [form, setForm] = useState({
-    name: "",
-    email: "",
-    password: "",
-    confirmPassword: "",
-    agreeTerms: false,
-  });
-
+  const { signupForm, setSignupForm, resetSignupForm } = storeSignupForm();
   // 에러 상태
   const [errors, setErrors] = useState({
     name: "",
@@ -69,15 +64,15 @@ export default function SignupForm() {
     cursor: pointer;
   `;
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const nameError = validateName(form.name);
-    const emailError = validateEmail(form.email);
-    const passwordError = validatePassword(form.password);
+    const nameError = validateName(signupForm.name);
+    const emailError = validateEmail(signupForm.email);
+    const passwordError = validatePassword(signupForm.password);
     const confirmPasswordError = validateConfirmPassword(
-      form.password,
-      form.confirmPassword
+      signupForm.password,
+      signupForm.confirmPassword
     );
 
     const newErrors = {
@@ -87,19 +82,32 @@ export default function SignupForm() {
       confirmPassword: confirmPasswordError,
     };
 
+    const signupReqForm: SignupReq = {
+      email: signupForm.email,
+      password: signupForm.password,
+      nickname: signupForm.name,
+    };
+
     setErrors(newErrors);
 
     // 에러 없으면 회원가입 로직 진행
     if (!nameError && !emailError && !passwordError && !confirmPasswordError) {
       // 약관 동의 체크
       // 어느 시점에서 해야하면 좋을 지 모르겠음
-      if (!form.agreeTerms) {
-        toast.error("이용약관 및 개인정보 처리방침에 동의해야 회원가입이 가능합니다.");
+      if (!signupForm.agreeTerms) {
+        toast.error(
+          "이용약관 및 개인정보 처리방침에 동의해야 회원가입이 가능합니다."
+        );
         return;
       }
-      toast.success("회원가입 요청을 보냈습니다!");
-      // TODO: 실제 회원가입 API 호출
-  }
+      try {
+        const res = await signupApi.POST.signup(signupReqForm);
+        toast.success(res.detail);
+        resetSignupForm();
+      } catch (e) {
+        toast.error(`회원 가입 중 오류 발생 : ${e}`);
+      }
+    }
   };
 
   return (
@@ -112,8 +120,8 @@ export default function SignupForm() {
           type="text"
           name="signup-name"
           placeholder="홍길동"
-          value={form.name}
-          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          value={signupForm.name}
+          onChange={(e) => setSignupForm({ name: e.target.value })}
           leftIcon={<FaUser />}
           error={errors.name}
         />
@@ -127,8 +135,8 @@ export default function SignupForm() {
           name="signup-email"
           placeholder="your@email.com"
           type="email"
-          value={form.email}
-          onChange={(e) => setForm({ ...form, email: e.target.value })}
+          value={signupForm.email}
+          onChange={(e) => setSignupForm({ email: e.target.value })}
           leftIcon={<FaEnvelope />}
           error={errors.email}
         />
@@ -142,8 +150,8 @@ export default function SignupForm() {
           name="signup-password"
           placeholder="안전한 비밀번호를 입력하세요"
           type="password"
-          value={form.password}
-          onChange={(e) => setForm({ ...form, password: e.target.value })}
+          value={signupForm.password}
+          onChange={(e) => setSignupForm({ password: e.target.value })}
           leftIcon={<FaLock />}
           error={errors.password}
         />
@@ -157,10 +165,8 @@ export default function SignupForm() {
           name="signup-confirm"
           placeholder="비밀번호를 다시 입력하세요"
           type="password"
-          value={form.confirmPassword}
-          onChange={(e) =>
-            setForm({ ...form, confirmPassword: e.target.value })
-          }
+          value={signupForm.confirmPassword}
+          onChange={(e) => setSignupForm({ confirmPassword: e.target.value })}
           leftIcon={<FaLock />}
           error={errors.confirmPassword}
         />
@@ -170,14 +176,19 @@ export default function SignupForm() {
         <input
           id="agreeTerms"
           type="checkbox"
-          checked={form.agreeTerms}
-          onChange={(e) => setForm({ ...form, agreeTerms: e.target.checked })}
+          checked={signupForm.agreeTerms}
+          onChange={(e) => setSignupForm({ agreeTerms: e.target.checked })}
         />
         이용약관 및 개인정보처리방침에 동의합니다
-        <a href="#" onClick={(e) => {
-          e.preventDefault();
-          navigate("/modal/terms"); // 약관 모달로 이동
-        }}>자세히 보기</a>
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate("/modal/terms"); // 약관 모달로 이동
+          }}
+        >
+          자세히 보기
+        </a>
       </label>
 
       <button type="button" onClick={handleSubmit} css={submit}>

--- a/src/components/modal/authmodal/TermsModal.tsx
+++ b/src/components/modal/authmodal/TermsModal.tsx
@@ -2,11 +2,20 @@
 import { css } from "@emotion/react";
 import { useNavigate } from "react-router-dom";
 import { useThemeColors } from "../../../hooks/useThemeColors";
+import { AnimatePresence, motion } from "framer-motion";
+import { useState } from "react";
 
 export default function TermsModal() {
   const navigate = useNavigate();
+  const [visible, setVisible] = useState(true);
 
-  const { modalBackground, addButtonBg} = useThemeColors();
+  const { modalBackground, addButtonBg } = useThemeColors();
+
+  
+const handleClose = () => {
+  setVisible(false);
+  setTimeout(() => navigate("/modal/auth?tab=register"), 250); 
+};
 
   const overlay = css`
     position: fixed;
@@ -54,67 +63,73 @@ export default function TermsModal() {
 
   return (
     <div css={overlay}>
-        <div css={modal}>
+      <AnimatePresence>
+        {visible&&<motion.div
+          css={modal}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.25 }}
+        >
+          <h2 css={title}>이용약관 및 개인정보 처리방침</h2>
+          <div css={content}>
+            <p>
+              본 약관은 <strong>[비서 AI]</strong> (이하 "회사")가 제공하는 모든
+              서비스의 이용과 관련하여 회사와 이용자 간의 권리, 의무 및
+              책임사항을 규정함을 목적으로 합니다.
+            </p>
 
+            <h3>1. 약관 동의</h3>
+            <p>
+              회원은 본 약관에 동의함으로써 서비스를 이용할 수 있으며, 동의하지
+              않을 경우 서비스 이용이 제한될 수 있습니다.
+            </p>
 
+            <h3>2. 서비스 이용</h3>
+            <p>
+              1) 서비스 이용은 관련 법령 및 회사 정책을 준수해야 합니다.
+              <br />
+              2) 회사는 시스템 점검 등으로 인해 일시적으로 서비스를 중단할 수
+              있습니다.
+            </p>
 
-      <h2 css={title}>이용약관 및 개인정보 처리방침</h2>
-      <div css={content}>
-        <p>
-          본 약관은 <strong>[비서 AI]</strong> (이하 "회사")가 제공하는
-          모든 서비스의 이용과 관련하여 회사와 이용자 간의 권리, 의무 및
-          책임사항을 규정함을 목적으로 합니다.
-        </p>
+            <h3>3. 개인정보 수집 및 이용</h3>
+            <p>
+              회사는 회원가입 및 서비스 제공을 위해 최소한의 개인정보를
+              수집합니다.
+              <br />
+              수집 항목: 이름, 이메일, 비밀번호
+              <br />
+              수집 목적: 회원관리, 서비스 제공, 고객 문의 대응
+            </p>
 
-        <h3>1. 약관 동의</h3>
-        <p>
-          회원은 본 약관에 동의함으로써 서비스를 이용할 수 있으며, 동의하지
-          않을 경우 서비스 이용이 제한될 수 있습니다.
-        </p>
+            <h3>4. 이용제한</h3>
+            <p>
+              회원이 다음 행위를 하는 경우 회사는 서비스 이용을 제한하거나
+              계정을 삭제할 수 있습니다.
+              <br />- 타인의 정보를 도용한 경우
+              <br />- 불법 콘텐츠를 게시하거나 전송한 경우
+              <br />- 서비스 운영을 방해한 경우
+            </p>
 
-        <h3>2. 서비스 이용</h3>
-        <p>
-          1) 서비스 이용은 관련 법령 및 회사 정책을 준수해야 합니다.
-          <br />
-          2) 회사는 시스템 점검 등으로 인해 일시적으로 서비스를 중단할 수
-          있습니다.
-        </p>
+            <h3>5. 책임 제한</h3>
+            <p>
+              회사는 천재지변, 불가항력적인 사유로 인한 서비스 장애에 대해서는
+              책임을 지지 않습니다.
+            </p>
 
-        <h3>3. 개인정보 수집 및 이용</h3>
-        <p>
-          회사는 회원가입 및 서비스 제공을 위해 최소한의 개인정보를 수집합니다.
-          <br />
-          수집 항목: 이름, 이메일, 비밀번호
-          <br />
-          수집 목적: 회원관리, 서비스 제공, 고객 문의 대응
-        </p>
+            <h3>6. 약관 변경</h3>
+            <p>
+              회사는 필요 시 본 약관을 변경할 수 있으며, 변경 사항은 서비스 내
+              공지사항 등을 통해 안내합니다.
+            </p>
+          </div>
 
-        <h3>4. 이용제한</h3>
-        <p>
-          회원이 다음 행위를 하는 경우 회사는 서비스 이용을 제한하거나 계정을
-          삭제할 수 있습니다.
-          <br />- 타인의 정보를 도용한 경우
-          <br />- 불법 콘텐츠를 게시하거나 전송한 경우
-          <br />- 서비스 운영을 방해한 경우
-        </p>
-
-        <h3>5. 책임 제한</h3>
-        <p>
-          회사는 천재지변, 불가항력적인 사유로 인한 서비스 장애에 대해서는
-          책임을 지지 않습니다.
-        </p>
-
-        <h3>6. 약관 변경</h3>
-        <p>
-          회사는 필요 시 본 약관을 변경할 수 있으며, 변경 사항은 서비스 내
-          공지사항 등을 통해 안내합니다.
-        </p>
-      </div>
-
-      <button css={closeBtn} onClick={() => navigate("/modal/auth")}>
-        뒤로가기
-      </button>
-        </div>
+          <button css={closeBtn} onClick={handleClose}>
+            뒤로가기
+          </button>
+        </motion.div>}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/sidebar/Rightbar/RightLogined.tsx
+++ b/src/components/sidebar/Rightbar/RightLogined.tsx
@@ -15,7 +15,6 @@ import { useNavigate } from "react-router-dom";
 import { dummySchedules } from "../../../api/dummyData/schedule";
 import { formatTime } from "../../../utils/time";
 import { useThemeColors } from "../../../hooks/useThemeColors";
-import { TokenManager } from "../../../api/apiClient";
 import { loginApi } from "../../../api/auth/login";
 
 const mocUser = {
@@ -217,7 +216,9 @@ export default function RightLogined({
 
   // 일정관리 페이지로 이동
   const handleSchedule = () => {
-    navigate("/modal/schedule");
+    navigate("/modal/schedule", { 
+  state: { prevPath: location.pathname } 
+});
   };
 
   const handleLogout = () => {

--- a/src/components/sidebar/Rightbar/RightLogined.tsx
+++ b/src/components/sidebar/Rightbar/RightLogined.tsx
@@ -15,6 +15,8 @@ import { useNavigate } from "react-router-dom";
 import { dummySchedules } from "../../../api/dummyData/schedule";
 import { formatTime } from "../../../utils/time";
 import { useThemeColors } from "../../../hooks/useThemeColors";
+import { TokenManager } from "../../../api/apiClient";
+import { loginApi } from "../../../api/auth/login";
 
 const mocUser = {
   user_id: 1,
@@ -218,6 +220,11 @@ export default function RightLogined({
     navigate("/modal/schedule");
   };
 
+  const handleLogout = () => {
+    setIsLogin(false);
+    loginApi.DELETE.logout();
+  };
+
   return (
     <div css={loginedContainerCss}>
       {/* 프로필 섹션 */}
@@ -290,7 +297,7 @@ export default function RightLogined({
 
       {/* 하단 버튼들 */}
       <div css={buttonSectionCss}>
-        <button css={baseButton} onClick={() => setIsLogin(false)}>
+        <button css={baseButton} onClick={handleLogout}>
           로그아웃
         </button>
         <button css={[baseButton]} onClick={goToPremium}>

--- a/src/components/sidebar/Rightbar/RightLogouted.tsx
+++ b/src/components/sidebar/Rightbar/RightLogouted.tsx
@@ -13,7 +13,9 @@ export default function RightLogouted() {
   const { modalBackground, scheduleTitleColor, crownIcon, scheduleItemBorder } = useThemeColors()
   const navi = useNavigate();
   const openLoginModal = () => {
-    navi("/modal/auth");
+    navi("/modal/auth", { 
+  state: { prevPath: location.pathname } 
+});
   };
 
   const premiumButtonCss = css`

--- a/src/components/sidebar/Rightbar/RightLogouted.tsx
+++ b/src/components/sidebar/Rightbar/RightLogouted.tsx
@@ -13,7 +13,7 @@ export default function RightLogouted() {
   const { modalBackground, scheduleTitleColor, crownIcon, scheduleItemBorder } = useThemeColors()
   const navi = useNavigate();
   const openLoginModal = () => {
-    navi("/modal/auth")
+    navi("/modal/auth");
   };
 
   const premiumButtonCss = css`
@@ -71,7 +71,7 @@ const logoutButtonSectionCss = css`
         <div css={[defaultProfileImage]}></div>
       </div>
       <div css={logoutButtonSectionCss}>
-        <button css={baseButton} onClick={openLoginModal}>
+        <button css={[baseButton, loginBtnCss]} onClick={openLoginModal}>
           로그인
         </button>
         <button css={premiumButtonCss} onClick={openLoginModal}>
@@ -82,3 +82,7 @@ const logoutButtonSectionCss = css`
     </div>
   );
 }
+
+const loginBtnCss = css`
+  cursor: pointer;
+`

--- a/src/components/sidebar/Rightbar/RightLogouted.tsx
+++ b/src/components/sidebar/Rightbar/RightLogouted.tsx
@@ -7,15 +7,13 @@ import {
 import { css } from "@emotion/react";
 import { FaCrown } from "react-icons/fa";
 import { useThemeColors } from "../../../hooks/useThemeColors";
+import { useNavigate } from "react-router-dom";
 
-export default function RightLogouted({
-  setIsLogin,
-}: {
-  setIsLogin: (bool: boolean) => void;
-}) {
+export default function RightLogouted() {
   const { modalBackground, scheduleTitleColor, crownIcon, scheduleItemBorder } = useThemeColors()
+  const navi = useNavigate();
   const openLoginModal = () => {
-    setIsLogin(true);
+    navi("/modal/auth")
   };
 
   const premiumButtonCss = css`

--- a/src/components/sidebar/Rightbar/Rightbar.tsx
+++ b/src/components/sidebar/Rightbar/Rightbar.tsx
@@ -1,12 +1,12 @@
 /** @jsxImportSource @emotion/react */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { GlassmorphismDesign } from "../../../styles/baseDesign/GlassmorphismDesign";
-import {
-  sideBarMixin,
-} from "../../../styles/mixins";
+import { sideBarMixin } from "../../../styles/mixins";
 import { RightbarPosition } from "./RightbarPosition";
 import RightLogined from "./RightLogined";
 import RightLogouted from "./RightLogouted";
+import { TokenManager } from "../../../api/apiClient";
+import { toast } from "react-toastify";
 
 // 팀 노션 api 명세서
 
@@ -35,7 +35,21 @@ import RightLogouted from "./RightLogouted";
 // const { completedText, descriptionText, addButtonBg } = useThemeColors();
 
 export function Rightbar() {
-  const [isLogin, setIsLogin] = useState<boolean>(true);
+  const [isLogin, setIsLogin] = useState<boolean>(false);
+
+  useEffect(() => {
+    (() => {
+      try {
+        setIsLogin(
+          !TokenManager.getAccessToken() || !TokenManager.getUserId()
+            ? false
+            : true
+        );
+      } catch (e) {
+        toast.error(`토큰 확인 중 오류가 발생했습니다:${e}`);
+      }
+    })();
+  }, []);
 
   return (
     <RightbarPosition>
@@ -44,7 +58,7 @@ export function Rightbar() {
           {isLogin ? (
             <RightLogined setIsLogin={setIsLogin} />
           ) : (
-            <RightLogouted setIsLogin={setIsLogin} />
+            <RightLogouted />
           )}
         </div>
       </GlassmorphismDesign>

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -5,7 +5,7 @@ export default function useModal() {
 
   const openModal = useCallback(() => {
     setIsOpen(true);
-  }, []);
+  }, [location.pathname]);
 
   const closeModal = useCallback(() => {
     setIsOpen(false);

--- a/src/store/storeSignupForm.ts
+++ b/src/store/storeSignupForm.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+
+export type ClientSignupForm = {
+  name: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  agreeTerms: boolean;
+};
+
+export const INIT_SIGNUP_FORM = {
+  name: "",
+  email: "",
+  password: "",
+  confirmPassword: "",
+  agreeTerms: false,
+};
+
+interface storeSignupForm {
+  signupForm: ClientSignupForm;
+  setSignupForm: (val: any) => void;
+  resetSignupForm: () => void;
+}
+
+export const storeSignupForm = create<storeSignupForm>((set) => ({
+  signupForm: INIT_SIGNUP_FORM,
+  setSignupForm: (val) =>
+    set((state) => ({ signupForm: { ...state.signupForm, ...val } })),
+  resetSignupForm: () => set(() => ({ signupForm: INIT_SIGNUP_FORM })),
+}));


### PR DESCRIPTION
로그인, 회원가입 탭 변경시 부드러운 애니메이션 적용
termsModal 에도 진입/뒤로가기 시 부드러운 애니메이션 적용
chat 쪽의 입력을 방해하던 불필요한 motion.div 의 입력 방지함
뒤로가기 기능이 본래 제대로 작동하지 않았으나 모달창 진입시 진입 시점의 컴포넌트에서 경로를 전달해주도록 변경해 제대로 이전 경로가 반영되도록 개선함
뒤로가기 버튼이 잘 보이지 않는 문제가 있었으나, 해당 요소의 부모에 position:relative를 주어 제대로 absolute가 적용되도록 변경함
![Honeycam 2025-10-01 18-51-30](https://github.com/user-attachments/assets/c42bbcef-65d6-426e-8da9-8f20f463f7e5)
회원가입 폼을 스토어에 저장해 termsModal이나 로그인으로 탭 이동해도 회원가입 폼이 저장되도록 개선함