### PR TITLE
Feature/api call

### DIFF
--- a/.github/workflows/deploy-dev.yml.bak
+++ b/.github/workflows/deploy-dev.yml.bak
@@ -23,14 +23,14 @@
 #               uses: aws-actions/configure-aws-credentials@v4
 #               with:
 #                   aws-region: ap-northeast-2
-#                   aws-access-key-id: ${{secrets.Dev_AWS_ACCESS_KEY_ID }}
-#                   aws-secret-access-key: ${{secrets.Dev_AWS_SECRET_ACCESS_KEY }}
+#                   aws-access-key-id: ${{secrets.DEV_AWS_ACCESS_KEY_ID }}
+#                   aws-secret-access-key: ${{secrets.DEV_AWS_SECRET_ACCESS_KEY }}
 
 #             - name: s3 파일들 전체 삭제 후 업로드
 #               run: |
-#                   aws s3 rm --recursive s3://${{ secrets.Dev_S3_BUCKET_NAME }}
-#                   aws s3 cp ./dist/ s3://${{ secrets.Dev_S3_BUCKET_NAME }}/ --recursive
+#                   aws s3 rm --recursive s3://${{ secrets.DEV_S3_BUCKET_NAME }}
+#                   aws s3 cp ./dist/ s3://${{ secrets.DEV_S3_BUCKET_NAME }}/ --recursive
 
 #             - name: 클라우드프론트 캐시 무효화
-#               run: aws cloudfront create-invalidation --distribution-id ${{ secrets.Dev_DISTRIBUTION_ID }} --paths "/*"
+#               run: aws cloudfront create-invalidation --distribution-id ${{ secrets.DEV_DISTRIBUTION_ID }} --paths "/*"
 

--- a/.github/workflows/deploy-dev.yml.bak
+++ b/.github/workflows/deploy-dev.yml.bak
@@ -23,14 +23,14 @@
 #               uses: aws-actions/configure-aws-credentials@v4
 #               with:
 #                   aws-region: ap-northeast-2
-#                   aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID }}
-#                   aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY }}
+#                   aws-access-key-id: ${{secrets.Dev_AWS_ACCESS_KEY_ID }}
+#                   aws-secret-access-key: ${{secrets.Dev_AWS_SECRET_ACCESS_KEY }}
 
 #             - name: s3 파일들 전체 삭제 후 업로드
 #               run: |
-#                   aws s3 rm --recursive s3://${{ secrets.S3_BUCKET_NAME }}
-#                   aws s3 cp ./dist/ s3://${{ secrets.S3_BUCKET_NAME }}/ --recursive
+#                   aws s3 rm --recursive s3://${{ secrets.Dev_S3_BUCKET_NAME }}
+#                   aws s3 cp ./dist/ s3://${{ secrets.Dev_S3_BUCKET_NAME }}/ --recursive
 
 #             - name: 클라우드프론트 캐시 무효화
-#               run: aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
+#               run: aws cloudfront create-invalidation --distribution-id ${{ secrets.Dev_DISTRIBUTION_ID }} --paths "/*"
 

--- a/.github/workflows/deploy-prod.yml.bak
+++ b/.github/workflows/deploy-prod.yml.bak
@@ -22,13 +22,13 @@
 #         uses: aws-actions/configure-aws-credentials@v4
 #         with: 
 #             aws-region: ap-northeast-2
-#             aws-access-key-id: ${{secrets.Prod_AWS_ACCESS_KEY_ID }}
-#             aws-secret-access-key: ${{secrets.Prod_AWS_SECRET_ACCESS_KEY }}
+#             aws-access-key-id: ${{secrets.PROD_AWS_ACCESS_KEY_ID }}
+#             aws-secret-access-key: ${{secrets.PROD_AWS_SECRET_ACCESS_KEY }}
 
 #       - name: s3 파일들 전체 삭제 후 업로드
 #         run: |
-#           aws s3 rm --recursive s3://${{ secrets.Prod_S3_BUCKET_NAME }}
-#           aws s3 cp ./dist/ s3://${{ secrets.Prod_S3_BUCKET_NAME }}/ --recursive
+#           aws s3 rm --recursive s3://${{ secrets.PROD_S3_BUCKET_NAME }}
+#           aws s3 cp ./dist/ s3://${{ secrets.PROD_S3_BUCKET_NAME }}/ --recursive
 
 #       - name: 클라우드프론트 캐시 무효화
-#         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.Prod_DISTRIBUTION_ID }} --paths "/*"
+#         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.PROD_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/deploy-prod.yml.bak
+++ b/.github/workflows/deploy-prod.yml.bak
@@ -22,13 +22,13 @@
 #         uses: aws-actions/configure-aws-credentials@v4
 #         with: 
 #             aws-region: ap-northeast-2
-#             aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID }}
-#             aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY }}
+#             aws-access-key-id: ${{secrets.Prod_AWS_ACCESS_KEY_ID }}
+#             aws-secret-access-key: ${{secrets.Prod_AWS_SECRET_ACCESS_KEY }}
 
 #       - name: s3 파일들 전체 삭제 후 업로드
 #         run: |
-#           aws s3 rm --recursive s3://${{ secrets.S3_BUCKET_NAME }}
-#           aws s3 cp ./dist/ s3://${{ secrets.S3_BUCKET_NAME }}/ --recursive
+#           aws s3 rm --recursive s3://${{ secrets.Prod_S3_BUCKET_NAME }}
+#           aws s3 cp ./dist/ s3://${{ secrets.Prod_S3_BUCKET_NAME }}/ --recursive
 
 #       - name: 클라우드프론트 캐시 무효화
-#         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/*"
+#         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.Prod_DISTRIBUTION_ID }} --paths "/*"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,14 @@ import React, { useEffect } from "react";
 import "./App.css";
 import Background from "./components/background/Background";
 import { Route, Routes } from "react-router-dom";
-import WindowSizeProvider from "./components/utilComponents/WindowSizeProvider";
+import WindowSizeSetter from "./components/utilComponents/WindowSizeProvider";
 import { MousePositonSetter } from "./components/utilComponents/MousePositionSetter";
 import { ToastContainer } from "react-toastify";
 
 // Home은 즉시 로드
 import Home from "./components/Home";
 import { ThemeModeBtn } from "./components/sidebar/Leftbar/ThemeModeBtn";
+import { NotiTypesSetter } from "./components/utilComponents/GetNotiTypes";
 
 const Modal = React.lazy(() => import("./components/modal/Modal"));
 const AuthModal = React.lazy(
@@ -40,9 +41,12 @@ export default function AppDesktop() {
 
   return (
     <>
+    {/* ui없는 기능성 컴포넌트 */}
+      <WindowSizeSetter />
+      <MousePositonSetter />
+      <NotiTypesSetter/>
+
       <Background>
-        <WindowSizeProvider />
-        <MousePositonSetter />
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/chat/:session_id" element={<Home />} />
@@ -59,7 +63,8 @@ export default function AppDesktop() {
           </Route>
         </Routes>
       </Background>
-      <ThemeModeBtn/>
+      {/* 배경 바뀔때 리랜더링 방지용으로 버튼을 따로 빼놓음 */}
+      <ThemeModeBtn />
 
       <ToastContainer
         position="top-center"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,19 +6,32 @@ import WindowSizeProvider from "./components/utilComponents/WindowSizeProvider";
 import { MousePositonSetter } from "./components/utilComponents/MousePositionSetter";
 import { ToastContainer } from "react-toastify";
 
-
 // Home은 즉시 로드
 import Home from "./components/Home";
+import { ThemeModeBtn } from "./components/sidebar/Leftbar/ThemeModeBtn";
 
 const Modal = React.lazy(() => import("./components/modal/Modal"));
-const AuthModal = React.lazy(() => import("./components/modal/authmodal/AuthModal"));
-const ScheduleModal = React.lazy(() => import("./components/modal/schedule_modal/scheduleModal"));
-const NotificationModal = React.lazy(() => import("./components/modal/notification_modal/NotificationModal"))
-const TermsModal = React.lazy(() => import("./components/modal/authmodal/TermsModal"));
-const PasswordChangeModal = React.lazy(() => import("./components/modal/passwordChang/PasswordChangeModal"))
-const DeleteAccountModal = React.lazy(() => import("./components/modal/deleteAccount_modal/DeleteAccountModal"))
-const ProfileSettingModal = React.lazy(() => import("./components/modal/profileSetting_modal/ProfileSettingModal"))
-
+const AuthModal = React.lazy(
+  () => import("./components/modal/authmodal/AuthModal")
+);
+const ScheduleModal = React.lazy(
+  () => import("./components/modal/schedule_modal/scheduleModal")
+);
+const NotificationModal = React.lazy(
+  () => import("./components/modal/notification_modal/NotificationModal")
+);
+const TermsModal = React.lazy(
+  () => import("./components/modal/authmodal/TermsModal")
+);
+const PasswordChangeModal = React.lazy(
+  () => import("./components/modal/passwordChang/PasswordChangeModal")
+);
+const DeleteAccountModal = React.lazy(
+  () => import("./components/modal/deleteAccount_modal/DeleteAccountModal")
+);
+const ProfileSettingModal = React.lazy(
+  () => import("./components/modal/profileSetting_modal/ProfileSettingModal")
+);
 
 export default function AppDesktop() {
   useEffect(() => {
@@ -27,40 +40,40 @@ export default function AppDesktop() {
 
   return (
     <>
-        <Background>
-          <WindowSizeProvider />
-          <MousePositonSetter />
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/chat/:session_id" element={<Home />} />
-            <Route path="/chat/new" element={<Home />} />
+      <Background>
+        <WindowSizeProvider />
+        <MousePositonSetter />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/chat/:session_id" element={<Home />} />
+          <Route path="/chat/new" element={<Home />} />
 
-              <Route path="modal" element={<Modal />}>
-                <Route path="auth" element={<AuthModal />} />
-                <Route path="terms" element={<TermsModal />} />
-                <Route path="schedule" element={<ScheduleModal />} />
-                <Route path="notification" element={<NotificationModal />} />
-                <Route path="password" element={<PasswordChangeModal />} />
-                <Route path="deleteaccount" element={<DeleteAccountModal />} />
-                <Route path="profilesetting" element={<ProfileSettingModal/>} />
-              </Route>
-            </Routes>
-        </Background>
+          <Route path="modal" element={<Modal />}>
+            <Route path="auth" element={<AuthModal />} />
+            <Route path="terms" element={<TermsModal />} />
+            <Route path="schedule" element={<ScheduleModal />} />
+            <Route path="notification" element={<NotificationModal />} />
+            <Route path="password" element={<PasswordChangeModal />} />
+            <Route path="deleteaccount" element={<DeleteAccountModal />} />
+            <Route path="profilesetting" element={<ProfileSettingModal />} />
+          </Route>
+        </Routes>
+      </Background>
+      <ThemeModeBtn/>
 
-        <ToastContainer
-              position="top-center"  // 위치
-              autoClose={3000}       // 3초 후 닫힘
-              hideProgressBar        // 프로그레스바 표시 여부
-              newestOnTop
-              closeOnClick
-              rtl={false}
-              pauseOnFocusLoss
-              draggable
-              pauseOnHover
-              theme="light"
-              style={{ zIndex: 9999 }} // 모달보다 높게 지정
-            />
-    
+      <ToastContainer
+        position="top-center"
+        autoClose={3000}
+        hideProgressBar
+        newestOnTop
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="light"
+        style={{ zIndex: 9999 }}
+      />
     </>
   );
 }

--- a/src/api/auth/profile.ts
+++ b/src/api/auth/profile.ts
@@ -21,7 +21,7 @@ export interface PutProfileRes {
   updated_at: string;
 }
 
-export const profileApi = {
+export const apiProfile = {
   GET: {
     /**
      * 현재 로그인한 사용자의 프로필 정보 조회

--- a/src/api/auth/withdraw.ts
+++ b/src/api/auth/withdraw.ts
@@ -1,0 +1,19 @@
+import { handleApiCall } from "../apiClient";
+
+type WithDrawReq = {
+  password: string;
+};
+
+export const apiWithDraw = {
+  DELETE: {
+    /**
+     * 회원 탈퇴 메서드
+     * @param {WithDrawReq} payload 패스워드
+     * @returns {Promise<ResDetail>} .detail에 메시지
+     */
+    withDraw: async (payload: WithDrawReq): Promise<ResDetail> => {
+      const url = `/users/delete/`;
+      return await handleApiCall({ method: "DELETE", url: url, data: payload });
+    },
+  },
+};

--- a/src/api/notification/notification.ts
+++ b/src/api/notification/notification.ts
@@ -1,6 +1,6 @@
 import { handleApiCall } from "../apiClient";
 
-type NotificationType = {
+export type NotificationType = {
   id: number;
   code: string;
   description: string;
@@ -34,47 +34,7 @@ interface DeleteNotificationByIdApiRes {
   detail: string;
 }
 
-// ---- 타입 정의 (API Response → UI 변환용) ----
-export interface NotificationUI {
-  id: number;
-  type: "ai" | "system"; // notification_type_id 매핑, 일단 임시로 ai | sistem으로 지정
-  title: string;
-  content: string;
-  link?: string;
-  isRead: boolean;
-  readAt?: string | null;
-  createdAt: string;
-  updatedAt: string;
-  time: string; // "xx분 전" 형식
-}
-
-// ---- 유틸 함수 ----
-export const formatRelativeTime = (isoDate: string): string => {
-  const now = new Date();
-  const target = new Date(isoDate);
-  const diff = Math.floor((now.getTime() - target.getTime()) / 1000);
-
-  if (diff < 60) return `${diff}초 전`;
-  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
-  return `${Math.floor(diff / 86400)}일 전`;
-};
-
-export const mapNotification = (apiData: Notification): NotificationUI => ({
-  id: apiData.id,
-  type: apiData.notification_type_id === 1 ? "ai" : "system",
-  title: apiData.title,
-  content: apiData.message,
-  link: apiData.link,
-  isRead: apiData.is_read,
-  readAt: apiData.read_at,
-  createdAt: apiData.created_at,
-  updatedAt: apiData.updated_at,
-  time: formatRelativeTime(apiData.created_at),
-});
-
-//후
-export const notificationApi = {
+export const apiNoti = {
   GET: {
     /**
      * 알림 타입을 받아오는 GET메서드

--- a/src/components/background/Background.tsx
+++ b/src/components/background/Background.tsx
@@ -4,17 +4,14 @@ import { storeColorMode } from "../../store/storeColorMode";
 import { themeKeys } from "../../styles/constColors";
 import { LightBg } from "./LightBg";
 import { DarkThemeBg } from "./DarkBg";
-import { Logo } from "./Logo";
 
 export default function Background({ children }: PropsWithChildren<{}>) {
   const mode = storeColorMode((state) => state.mode);
-  const content = (
-    <>
-      <Logo />
+  const Wrapper = mode === themeKeys[0] ? DarkThemeBg : LightBg;
+  
+  return (
+    <Wrapper>
       {children}
-    </>
+    </Wrapper>
   );
-
-  if (mode === themeKeys[0]) return <DarkThemeBg>{content}</DarkThemeBg>;
-  return <LightBg>{content}</LightBg>;
 }

--- a/src/components/background/Logo.tsx
+++ b/src/components/background/Logo.tsx
@@ -1,3 +1,0 @@
-export function Logo() {
-    return (<></>);
-}

--- a/src/components/chat/MsgSendBox.tsx
+++ b/src/components/chat/MsgSendBox.tsx
@@ -41,7 +41,7 @@ export function MsgSendBox({ sessionId, setMessages }: MsgSendBoxProps) {
       setMessages((prev) => [...prev, newMsg]);
       setInput("");
     } catch (err) {
-      console.error("메시지 전송 실패:", err);
+      toast.error(`메시지 전송 실패:${err}`, );
     }
   };
 

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -34,7 +34,7 @@ export default function Modal() {
     window.history.length > 1
       ? navigate(prevPath, { replace: true })
       : navigate("/", { replace: true });
-    console.log(prevPath);
+    // console.log(prevPath);
 
     resetSignupForm();
   };

--- a/src/components/modal/authmodal/LoginForm.tsx
+++ b/src/components/modal/authmodal/LoginForm.tsx
@@ -7,9 +7,11 @@ import { useThemeColors } from "../../../hooks/useThemeColors";
 import { validateEmail, validatePassword } from "../../../utils/validator";
 import { loginApi, type LoginReq } from "../../../api/auth/login";
 import { toast } from "react-toastify";
+import { storeUserEmail } from "../../../store/storeUserEmail";
 
 export default function LoginForm() {
   const [form, setForm] = useState<LoginReq>({ email: "", password: "" });
+  const { setUserEmail: setEmail } = storeUserEmail();
 
   const [errors, setErrors] = useState({
     email: "",
@@ -76,6 +78,8 @@ export default function LoginForm() {
     if (!emailError && !passwordError) {
       try {
         const res = await loginApi.POST.login(form);
+        setEmail(res.email);
+
         toast.success(res.detail);
       } catch (e) {
         toast.error(`로그인 에러 발생 : ${e}`);

--- a/src/components/modal/authmodal/LoginForm.tsx
+++ b/src/components/modal/authmodal/LoginForm.tsx
@@ -70,7 +70,7 @@ export default function LoginForm() {
 
     setErrors(newErrors);
 
-    console.log(form);
+    // console.log(form);
 
     // 에러 없으면 로그인 로직 진행
     if (!emailError && !passwordError) {

--- a/src/components/modal/authmodal/SignupForm.tsx
+++ b/src/components/modal/authmodal/SignupForm.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-import {  useState } from "react";
+import { useState } from "react";
 import { FaUser, FaEnvelope, FaLock } from "react-icons/fa";
 import { InputField } from "../../InputField";
 import { useThemeColors } from "../../../hooks/useThemeColors";
@@ -14,10 +14,12 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import { signupApi, type SignupReq } from "../../../api/auth/signup";
 import { storeSignupForm } from "../../../store/storeSignupForm";
+import { storeUserEmail } from "../../../store/storeUserEmail";
 
 export default function SignupForm() {
   const navigate = useNavigate();
   const { signupForm, setSignupForm, resetSignupForm } = storeSignupForm();
+  const { setUserEmail: setEmail } = storeUserEmail();
   // 에러 상태
   const [errors, setErrors] = useState({
     name: "",
@@ -102,6 +104,7 @@ export default function SignupForm() {
       }
       try {
         const res = await signupApi.POST.signup(signupReqForm);
+        setEmail(res.email);
         toast.success(res.detail);
         resetSignupForm();
       } catch (e) {
@@ -122,7 +125,7 @@ export default function SignupForm() {
           placeholder="홍길동"
           value={signupForm.name}
           onChange={(e) => setSignupForm({ name: e.target.value })}
-          leftIcon={<FaUser color={inputBorder}/>}
+          leftIcon={<FaUser color={inputBorder} />}
           error={errors.name}
         />
       </div>
@@ -137,7 +140,7 @@ export default function SignupForm() {
           type="email"
           value={signupForm.email}
           onChange={(e) => setSignupForm({ email: e.target.value })}
-          leftIcon={<FaEnvelope color={inputBorder}/>}
+          leftIcon={<FaEnvelope color={inputBorder} />}
           error={errors.email}
         />
       </div>
@@ -167,7 +170,7 @@ export default function SignupForm() {
           type="password"
           value={signupForm.confirmPassword}
           onChange={(e) => setSignupForm({ confirmPassword: e.target.value })}
-          leftIcon={<FaLock color={inputBorder}/>}
+          leftIcon={<FaLock color={inputBorder} />}
           error={errors.confirmPassword}
         />
       </div>

--- a/src/components/modal/deleteAccount_modal/DeleteAccountModal.tsx
+++ b/src/components/modal/deleteAccount_modal/DeleteAccountModal.tsx
@@ -1,121 +1,132 @@
 /** @jsxImportSource @emotion/react */
-import { css } from '@emotion/react';
-import { IoPersonRemoveOutline, IoWarningOutline } from 'react-icons/io5';
-import { useThemeColors } from '../../../hooks/useThemeColors';
+import { css } from "@emotion/react";
+import { IoPersonRemoveOutline, IoWarningOutline } from "react-icons/io5";
+import { useThemeColors } from "../../../hooks/useThemeColors";
 
 const DeleteAccountModal = () => {
+  const {
+    modalBackground,
+    deleteBtnBg,
+    hoverDeleteBtn,
+    iconContainerBg,
+    descriptionText,
+    worningBoxBg,
+    worningBoxBorder,
+    inputBorder,
+    completedText,
+    headerBorder,
+    scheduleTitleColor,
+  } = useThemeColors();
 
-    const { modalBackground, deleteBtnBg, hoverDeleteBtn, iconContainerBg, descriptionText, worningBoxBg, worningBoxBorder, inputBorder, completedText, headerBorder, scheduleTitleColor } = useThemeColors()
+  const modalContainerStyle = css`
+    background: ${modalBackground};
+    border-radius: 16px;
+    padding: 32px;
+    min-width: 440px;
+    max-width: 500px;
+  `;
 
-const modalContainerStyle = css`
-  background: ${modalBackground};
-  border-radius: 16px;
-  padding: 32px;
-  min-width: 440px;
-  max-width: 500px;
-`;
+  const headerStyle = css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin-bottom: 24px;
+  `;
 
-const headerStyle = css`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  margin-bottom: 24px;
-`;
+  const iconContainerStyle = css`
+    width: 64px;
+    height: 64px;
+    background: ${iconContainerBg};
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 16px;
+  `;
 
-const iconContainerStyle = css`
-  width: 64px;
-  height: 64px;
-  background: ${iconContainerBg};
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 16px;
-`;
+  const titleStyle = css`
+    font-size: 20px;
+    font-weight: 600;
+    color: ${deleteBtnBg};
+    margin: 0 0 8px 0;
+  `;
 
-const titleStyle = css`
-  font-size: 20px;
-  font-weight: 600;
-  color: ${deleteBtnBg};
-  margin: 0 0 8px 0;
-`;
+  const subtitleStyle = css`
+    font-size: 14px;
+    color: ${descriptionText};
+    margin: 0;
+  `;
 
-const subtitleStyle = css`
-  font-size: 14px;
-  color: ${descriptionText};
-  margin: 0;
-`;
+  const warningBoxStyle = css`
+    background: ${worningBoxBg};
+    border: 2px solid ${worningBoxBorder};
+    border-radius: 12px;
+    padding: 20px;
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+    margin-bottom: 24px;
+  `;
 
-const warningBoxStyle = css`
-  background: ${worningBoxBg};
-  border: 2px solid ${worningBoxBorder};
-  border-radius: 12px;
-  padding: 20px;
-  display: flex;
-  gap: 16px;
-  align-items: flex-start;
-  margin-bottom: 24px;
-`;
+  const warningIconStyle = css`
+    color: ${deleteBtnBg};
+    flex-shrink: 0;
+    margin-top: 2px;
+  `;
 
-const warningIconStyle = css`
-  color: ${deleteBtnBg};
-  flex-shrink: 0;
-  margin-top: 2px;
-`;
+  const warningTitleStyle = css`
+    font-size: 16px;
+    font-weight: 600;
+    color: ${deleteBtnBg};
+    margin: 0 0 4px 0;
+  `;
 
-const warningTitleStyle = css`
-  font-size: 16px;
-  font-weight: 600;
-  color: ${deleteBtnBg};
-  margin: 0 0 4px 0;
-`;
+  const warningTextStyle = css`
+    font-size: 14px;
+    color: ${hoverDeleteBtn};
+    margin: 0;
+    line-height: 1.5;
+  `;
 
-const warningTextStyle = css`
-  font-size: 14px;
-  color: ${hoverDeleteBtn};
-  margin: 0;
-  line-height: 1.5;
-`;
+  const buttonContainerStyle = css`
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+  `;
 
-const buttonContainerStyle = css`
-  display: flex;
-  gap: 12px;
-  justify-content: flex-end;
-`;
+  const cancelButtonStyle = css`
+    padding: 12px 24px;
+    border: 2px solid ${inputBorder};
+    background: ${modalBackground};
+    color: ${completedText};
+    font-size: 14px;
+    font-weight: 500;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: all 0.2s ease;
 
-const cancelButtonStyle = css`
-  padding: 12px 24px;
-  border: 2px solid ${inputBorder};
-  background: ${modalBackground};
-  color: ${completedText};
-  font-size: 14px;
-  font-weight: 500;
-  border-radius: 10px;
-  cursor: pointer;
-  transition: all 0.2s ease;
+    &:hover {
+      border-color: ${headerBorder};
+      color: ${scheduleTitleColor};
+    }
+  `;
 
-  &:hover {
-    border-color: ${headerBorder};
-    color: ${scheduleTitleColor};
-  }
-`;
+  const deleteButtonStyle = css`
+    padding: 12px 24px;
+    border: none;
+    background: ${deleteBtnBg};
+    color: ${modalBackground};
+    font-size: 14px;
+    font-weight: 500;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: all 0.2s ease;
 
-const deleteButtonStyle = css`
-  padding: 12px 24px;
-  border: none;
-  background: ${deleteBtnBg};
-  color: ${modalBackground};
-  font-size: 14px;
-  font-weight: 500;
-  border-radius: 10px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-
-  &:hover {
-    background: ${hoverDeleteBtn};
-  }
-`;
+    &:hover {
+      background: ${hoverDeleteBtn};
+    }
+  `;
 
   const handleCancel = (): void => {
     // 회원 탈퇴 취소
@@ -154,7 +165,5 @@ const deleteButtonStyle = css`
     </div>
   );
 };
-
-
 
 export default DeleteAccountModal;

--- a/src/components/modal/deleteAccount_modal/DeleteAccountModal.tsx
+++ b/src/components/modal/deleteAccount_modal/DeleteAccountModal.tsx
@@ -2,6 +2,9 @@
 import { css } from "@emotion/react";
 import { IoPersonRemoveOutline, IoWarningOutline } from "react-icons/io5";
 import { useThemeColors } from "../../../hooks/useThemeColors";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import { apiWithDraw } from "../../../api/auth/withdraw";
 
 const DeleteAccountModal = () => {
   const {
@@ -17,6 +20,7 @@ const DeleteAccountModal = () => {
     headerBorder,
     scheduleTitleColor,
   } = useThemeColors();
+  const navi = useNavigate();
 
   const modalContainerStyle = css`
     background: ${modalBackground};
@@ -129,11 +133,24 @@ const DeleteAccountModal = () => {
   `;
 
   const handleCancel = (): void => {
-    // 회원 탈퇴 취소
+    try {
+      navi(-1);
+    } catch (e) {
+      toast.error(`뒤로가기 중 오류가 발생했습니다 : ${e}`)
+      navi("/")
+    }
   };
 
-  const handleConfirm = (): void => {
-    // 회원 탈퇴 진행
+  // 패스워드 값 필요함!!!!
+  const payload = {password:""};
+
+  const handleConfirm = async() => {
+    try {
+      const res = await apiWithDraw.DELETE.withDraw(payload);
+      toast.success(`${res.detail}`)
+    } catch (error) {
+      
+    }
   };
 
   return (

--- a/src/components/modal/notification_modal/NotificationHeader.tsx
+++ b/src/components/modal/notification_modal/NotificationHeader.tsx
@@ -2,8 +2,8 @@
 import { IoNotifications } from "react-icons/io5";
 import { css } from "@emotion/react";
 import { useThemeColors } from "../../../hooks/useThemeColors";
+import type { TabType } from "./NotificationModal";
 
-type TabType = "all" | "unread";
 
 interface NotificationHeaderProps {
   activeTab: TabType;
@@ -140,8 +140,8 @@ const markAllReadButton = css`
       {/* 탭 */}
       <div css={tabContainer}>
         <button
-          css={[tab, activeTab === "all" && activeTabStyle]}
-          onClick={() => setActiveTab("all")}
+          css={[tab, activeTab === "read" && activeTabStyle]}
+          onClick={() => setActiveTab("read")}
         >
           전체
         </button>

--- a/src/components/modal/notification_modal/NotificationModal.tsx
+++ b/src/components/modal/notification_modal/NotificationModal.tsx
@@ -13,6 +13,7 @@ import {
 import { scrollCss } from "../../../styles/mixins";
 import { useThemeColors } from "../../../hooks/useThemeColors";
 import { Notifications } from "../../../api/dummyData/notification";
+import { toast } from "react-toastify";
 
 type TabType = "all" | "unread";
 
@@ -46,16 +47,15 @@ const NotificationModal = () => {
   useEffect(() => {
     const fetchNotifications = async () => {
       try {
-        // 👉 API 스펙에 "all"이 없다면 read+unread 합쳐야 합니다.
         const status = activeTab === "all" ? "read" : "unread";
         const res = await notificationApi.GET.notifications(status);
         const mapped = res.map((n) => mapNotification(n));
         setNotifications(mapped);
       } catch (err) {
-        console.error("알림 불러오기 실패:", err);
-      } finally{
+        toast.error(`알림 불러오기 실패:${err}`);
+      } finally {
         const mapped = Notifications.map((n) => mapNotification(n));
-        setNotifications(mapped)
+        setNotifications(mapped);
       }
     };
 
@@ -74,7 +74,7 @@ const NotificationModal = () => {
         )
       );
     } catch (err) {
-      console.error("읽음 처리 실패:", err);
+      toast.error(`읽음 처리 실패:${err}`);
     }
   };
 
@@ -84,7 +84,7 @@ const NotificationModal = () => {
       await notificationApi.DELETE.notificationById(id);
       setNotifications((prev) => prev.filter((item) => item.id !== id));
     } catch (err) {
-      console.error("알림 삭제 실패:", err);
+      toast.error(`알림 삭제 실패:${err}`);
     }
   };
 
@@ -104,7 +104,7 @@ const NotificationModal = () => {
         )
       );
     } catch (err) {
-      console.error("전체 읽음 처리 실패:", err);
+      toast.error(`전체 읽음 처리 실패:${err}`, );
     }
   };
 

--- a/src/components/modal/notification_modal/NotificationModal.tsx
+++ b/src/components/modal/notification_modal/NotificationModal.tsx
@@ -5,23 +5,52 @@ import { motion } from "framer-motion";
 import NotificationHeader from "./NotificationHeader";
 import NotificationAllTab from "./NotificationAllTab";
 import NotificationUnreadTab from "./NotificationUnreadTab";
-import type { NotificationUI } from "../../../api/notification/notification";
-import {
-  mapNotification,
-  notificationApi,
-} from "../../../api/notification/notification";
+import { apiNoti } from "../../../api/notification/notification";
 import { scrollCss } from "../../../styles/mixins";
 import { useThemeColors } from "../../../hooks/useThemeColors";
 import { Notifications } from "../../../api/dummyData/notification";
 import { toast } from "react-toastify";
+import { type Notification } from "../../../api/notification/notification";
+import { formatRelativeTime } from "../../../utils/time";
+import { storeNotiTypes } from "../../../store/storeNotiTypes";
+import _ from "lodash";
 
-type TabType = "all" | "unread";
+export type TabType = "read" | "unread";
+// all 기능 없음
+// status all일때 read // unread 로 api 보내는 것은 부적절
+// 백 코드에 맞게 read, unread로 통일
+// all 을 할거면 백 코드에 all 요청 추가 혹은 api 콜 두번 보내야 함
+
+type NotificationUI = {
+  id: number;
+  type: string;
+  title: string;
+  message: string;
+  link?: string;
+  is_read: boolean;
+  read_at?: string | null;
+  created_at: string;
+  updated_at: string;
+  time: string; // "xx분 전" 형식
+};
 
 const NotificationModal = () => {
-  const [activeTab, setActiveTab] = useState<TabType>("all");
+  const [activeTab, setActiveTab] = useState<TabType>("unread");
   const [notifications, setNotifications] = useState<NotificationUI[]>([]);
 
   const { inputBorder, modalBackground } = useThemeColors();
+  const { notiTypes } = storeNotiTypes();
+
+  // 맵 노티 이동(스토어 활용)
+  // 기존에 원본 타입과 키값이 달라 같은 밸류를 다른 키값으로 반복적으로 매핑되던것을 원본 타입에 맞춰 수정함
+  // notiTypes가 서버측에서 타입들을 뽑아오는것이어서 undefined 가능
+  // undefined일땐 unknown으로 지정함
+  const mapNotification = (n: Notification): NotificationUI => {
+    const typeCode =
+      notiTypes.find((el) => el.id === n.notification_type_id)?.code ||
+      "unknown";
+    return { ...n, type: typeCode, time: formatRelativeTime(n.created_at) };
+  };
 
   const modalContainer = css`
     background: ${modalBackground};
@@ -47,8 +76,7 @@ const NotificationModal = () => {
   useEffect(() => {
     const fetchNotifications = async () => {
       try {
-        const status = activeTab === "all" ? "read" : "unread";
-        const res = await notificationApi.GET.notifications(status);
+        const res = await apiNoti.GET.notifications(activeTab);
         const mapped = res.map((n) => mapNotification(n));
         setNotifications(mapped);
       } catch (err) {
@@ -65,11 +93,11 @@ const NotificationModal = () => {
   // 🔹 알림 단건 읽음 처리
   const handleMarkAsRead = async (id: number) => {
     try {
-      await notificationApi.PATCH.notificationStatusById(id);
+      const res = await apiNoti.PATCH.notificationStatusById(id);
       setNotifications((prev) =>
         prev.map((item) =>
           item.id === id
-            ? { ...item, isRead: true, readAt: new Date().toISOString() }
+            ? { ...item, is_read: res.is_read, read_at: res.updated_at }
             : item
         )
       );
@@ -81,8 +109,9 @@ const NotificationModal = () => {
   // 🔹 알림 삭제
   const handleDeleteNotification = async (id: number) => {
     try {
-      await notificationApi.DELETE.notificationById(id);
+      const res = await apiNoti.DELETE.notificationById(id);
       setNotifications((prev) => prev.filter((item) => item.id !== id));
+      toast.info(`${res.detail}`);
     } catch (err) {
       toast.error(`알림 삭제 실패:${err}`);
     }
@@ -91,24 +120,65 @@ const NotificationModal = () => {
   // 🔹 전체 읽음 처리
   const handleMarkAllAsRead = async () => {
     try {
-      await Promise.all(
-        notifications
-          .filter((n) => !n.isRead)
-          .map((n) => notificationApi.PATCH.notificationStatusById(n.id))
-      );
-      setNotifications((prev) =>
-        prev.map((item) =>
-          item.isRead
-            ? item
-            : { ...item, isRead: true, readAt: new Date().toISOString() }
+      const unreadNotifications = notifications.filter((n) => !n.is_read);
+      if (unreadNotifications.length === 0) return;
+
+      // Promise.all의 경우 실패시 다른 요청 전부 무시됨
+      // Promise.allSettled로 중간에 실패 나와도 처리 시도하도록 변경
+      const res = await Promise.allSettled(
+        unreadNotifications.map((n) =>
+          apiNoti.PATCH.notificationStatusById(n.id)
         )
       );
+
+      // zip+reduce는 한번 순회
+      // map+filter는 두번 순회
+      const zipped = _.zip(res, unreadNotifications);
+
+      const { failedCalls, successfulIds } = zipped.reduce(
+        (acc, [result, noti]) => {
+          if (!result || !noti) return acc;
+          if (result.status === "rejected") {
+            acc.failedCalls.push({
+              title: noti.title,
+              id: noti.id,
+            });
+          } else if (result.status === "fulfilled") {
+            acc.successfulIds.push(noti.id);
+          }
+          return acc;
+        },
+        { failedCalls: [], successfulIds: [] } as {
+          failedCalls: { title: string; id: number }[];
+          successfulIds: number[];
+        }
+      );
+
+      // 상태 업데이트 용 성공 id(실패한거는 업데이트 x)
+      setNotifications((prev) =>
+        prev.map((item) =>
+          successfulIds.includes(item.id)
+            ? { ...item, is_read: true, read_at: new Date().toISOString() }
+            : item
+        )
+      );
+
+      // 실패한 요청들 한번에 처리
+      if (failedCalls.length > 0) {
+        const titles = failedCalls.map((el) => el.title).join(", ");
+        const ids = failedCalls.map((el) => el.id).join(", ");
+        // 사용자는 주로 제목을 보기에 제목은 토스트로,
+        // 디버깅용으론 id를 주로 체크하기에 콘솔쪽은 id로 에러 전송
+        console.error(`일부 알림 읽음 처리 실패: id ${ids}`);
+        throw Error(`요청실패 : ${titles}`);
+      }
     } catch (err) {
-      toast.error(`전체 읽음 처리 실패:${err}`, );
+      toast.error(`전체 읽음 처리 중 예상치 못한 오류: ${err}`);
+      // console.error(err);
     }
   };
 
-  const unreadCount = notifications.filter((n) => !n.isRead).length;
+  const unreadCount = notifications.filter((n) => !n.is_read).length;
 
   return (
     <motion.div
@@ -124,7 +194,7 @@ const NotificationModal = () => {
       />
 
       <div css={[content, scrollCss(inputBorder)]}>
-        {activeTab === "all" ? (
+        {activeTab === "read" ? (
           <NotificationAllTab
             notifications={notifications}
             onMarkAsRead={handleMarkAsRead}

--- a/src/components/modal/profileSetting_modal/ProfileSettingModal.tsx
+++ b/src/components/modal/profileSetting_modal/ProfileSettingModal.tsx
@@ -3,13 +3,13 @@ import { css } from "@emotion/react";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useThemeColors } from "../../../hooks/useThemeColors";
-// import { useProfile } from '../../../hooks/api/useProfile'; // 실제 api
 import AccountInfo from "./AccountInfo";
 import ProfileImage from "./ProfileImage";
 import Nickname from "./Nickname";
 import { FiUser } from "react-icons/fi";
 import { toast } from "react-toastify";
 import { apiProfile } from "../../../api/auth/profile";
+import { storeUserEmail } from "../../../store/storeUserEmail";
 
 // 실제 api 콜로 수정
 const useProfile = () => {
@@ -31,6 +31,7 @@ const ProfileSettingsModal = () => {
   const navigate = useNavigate();
   const { getProfile, updateProfile } = useProfile();
   const { modalBackground, inputBorder, scheduleTitleColor } = useThemeColors();
+  const {userEmail} = storeUserEmail();
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -55,7 +56,7 @@ const ProfileSettingsModal = () => {
 
       setInitialImageUrl(data.profile_image_url);
       setInitialNickname(data.nickname);
-      setEmail("test@example.com"); // TODO: 실제 이메일 정보 연동 필요
+      setEmail(userEmail); 
 
       setPreviewImage(data.profile_image_url);
       setNickname(data.nickname);

--- a/src/components/modal/profileSetting_modal/ProfileSettingModal.tsx
+++ b/src/components/modal/profileSetting_modal/ProfileSettingModal.tsx
@@ -9,34 +9,19 @@ import ProfileImage from "./ProfileImage";
 import Nickname from "./Nickname";
 import { FiUser } from "react-icons/fi";
 import { toast } from "react-toastify";
+import { apiProfile } from "../../../api/auth/profile";
 
-// 테스트용 더미 훅 (실제 API 대신 사용)
+// 실제 api 콜로 수정
 const useProfile = () => {
   const getProfile = async () => {
-    return new Promise<{ profile_image_url: string; nickname: string }>(
-      (resolve) => {
-        setTimeout(() => {
-          resolve({
-            profile_image_url: "https://i.pravatar.cc/150?img=37",
-            nickname: "테스트 유저",
-          });
-        }, 500);
-      }
-    );
+    return await apiProfile.GET.profile();
   };
 
   const updateProfile = async (data: {
     profile_image_url?: string | null;
     nickname?: string;
   }) => {
-    // console.log("프로필 업데이트 시도:", data);
-    // 실제 API 대신 콘솔 출력
-    return new Promise<void>((resolve) => {
-      setTimeout(() => {
-        // console.log("업데이트 성공 (더미)", data);
-        resolve();
-      }, 500);
-    });
+    return await apiProfile.PUT.profile(data);
   };
 
   return { getProfile, updateProfile };

--- a/src/components/modal/profileSetting_modal/ProfileSettingModal.tsx
+++ b/src/components/modal/profileSetting_modal/ProfileSettingModal.tsx
@@ -1,34 +1,39 @@
 /** @jsxImportSource @emotion/react */
-import { css } from '@emotion/react';
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useThemeColors } from '../../../hooks/useThemeColors';
+import { css } from "@emotion/react";
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useThemeColors } from "../../../hooks/useThemeColors";
 // import { useProfile } from '../../../hooks/api/useProfile'; // 실제 api
-import AccountInfo from './AccountInfo';
-import ProfileImage from './ProfileImage';
-import Nickname from './Nickname';
+import AccountInfo from "./AccountInfo";
+import ProfileImage from "./ProfileImage";
+import Nickname from "./Nickname";
 import { FiUser } from "react-icons/fi";
-import { toast } from 'react-toastify';
+import { toast } from "react-toastify";
 
 // 테스트용 더미 훅 (실제 API 대신 사용)
 const useProfile = () => {
   const getProfile = async () => {
-    return new Promise<{ profile_image_url: string; nickname: string }>((resolve) => {
-      setTimeout(() => {
-        resolve({
-          profile_image_url: "https://i.pravatar.cc/150?img=37",
-          nickname: "테스트 유저",
-        });
-      }, 500);
-    });
+    return new Promise<{ profile_image_url: string; nickname: string }>(
+      (resolve) => {
+        setTimeout(() => {
+          resolve({
+            profile_image_url: "https://i.pravatar.cc/150?img=37",
+            nickname: "테스트 유저",
+          });
+        }, 500);
+      }
+    );
   };
 
-  const updateProfile = async (data: { profile_image_url?: string | null; nickname?: string }) => {
-    console.log("프로필 업데이트 시도:", data);
+  const updateProfile = async (data: {
+    profile_image_url?: string | null;
+    nickname?: string;
+  }) => {
+    // console.log("프로필 업데이트 시도:", data);
     // 실제 API 대신 콘솔 출력
     return new Promise<void>((resolve) => {
       setTimeout(() => {
-        console.log("업데이트 성공 (더미)", data);
+        // console.log("업데이트 성공 (더미)", data);
         resolve();
       }, 500);
     });
@@ -37,7 +42,6 @@ const useProfile = () => {
   return { getProfile, updateProfile };
 };
 
-
 const ProfileSettingsModal = () => {
   const navigate = useNavigate();
   const { getProfile, updateProfile } = useProfile();
@@ -45,15 +49,15 @@ const ProfileSettingsModal = () => {
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  
+
   // 초기 데이터
   const [initialImageUrl, setInitialImageUrl] = useState<string | null>(null);
-  const [initialNickname, setInitialNickname] = useState('');
-  const [email, setEmail] = useState('');
-  
+  const [initialNickname, setInitialNickname] = useState("");
+  const [email, setEmail] = useState("");
+
   // 현재 편집 중인 데이터
   const [previewImage, setPreviewImage] = useState<string | null>(null);
-  const [nickname, setNickname] = useState('');
+  const [nickname, setNickname] = useState("");
 
   useEffect(() => {
     loadProfile();
@@ -63,16 +67,15 @@ const ProfileSettingsModal = () => {
     try {
       setLoading(true);
       const data = await getProfile();
-      
+
       setInitialImageUrl(data.profile_image_url);
       setInitialNickname(data.nickname);
-      setEmail('test@example.com'); // TODO: 실제 이메일 정보 연동 필요
-      
+      setEmail("test@example.com"); // TODO: 실제 이메일 정보 연동 필요
+
       setPreviewImage(data.profile_image_url);
       setNickname(data.nickname);
     } catch (error) {
-      console.error('프로필 로드 실패:', error);
-      toast.error('프로필 정보를 불러오는데 실패했습니다.');
+      toast.error(`프로필 정보를 불러오는데 실패했습니다:${error}`);
       navigate(-1);
     } finally {
       setLoading(false);
@@ -90,7 +93,7 @@ const ProfileSettingsModal = () => {
   // 변경사항 자동 저장 (닉네임 또는 이미지 변경 시)
   useEffect(() => {
     if (loading || saving) return;
-    
+
     const hasImageChange = previewImage !== initialImageUrl;
     const hasNicknameChange = nickname !== initialNickname;
 
@@ -99,21 +102,24 @@ const ProfileSettingsModal = () => {
     const saveChanges = async () => {
       try {
         setSaving(true);
-        
-        const updateData: { profile_image_url?: string | null; nickname?: string } = {};
+
+        const updateData: {
+          profile_image_url?: string | null;
+          nickname?: string;
+        } = {};
         if (hasImageChange) updateData.profile_image_url = previewImage;
         if (hasNicknameChange) updateData.nickname = nickname;
 
         await updateProfile(updateData);
-        
+
         // 초기값 업데이트
         if (hasImageChange) setInitialImageUrl(previewImage);
         if (hasNicknameChange) setInitialNickname(nickname);
-        
+
         // 플로팅 바 업데이트
-        window.dispatchEvent(new Event('profile-updated'));
+        window.dispatchEvent(new Event("profile-updated"));
       } catch (error) {
-        console.error('프로필 자동 저장 실패:', error);
+        toast.error(`프로필 자동 저장 실패:${error}`);
         // 실패 시 원래 값으로 되돌리기
         setPreviewImage(initialImageUrl);
         setNickname(initialNickname);
@@ -125,7 +131,14 @@ const ProfileSettingsModal = () => {
     // 디바운스 (500ms)
     const timeoutId = setTimeout(saveChanges, 500);
     return () => clearTimeout(timeoutId);
-  }, [previewImage, nickname, initialImageUrl, initialNickname, loading, saving]);
+  }, [
+    previewImage,
+    nickname,
+    initialImageUrl,
+    initialNickname,
+    loading,
+    saving,
+  ]);
 
   const modalStyle = css`
     background: ${modalBackground};
@@ -164,7 +177,7 @@ const ProfileSettingsModal = () => {
   const hrStyle = css`
     border: 0.01rem solid ${inputBorder};
     margin-bottom: 2rem;
-  `
+  `;
 
   if (loading) {
     return (
@@ -177,7 +190,7 @@ const ProfileSettingsModal = () => {
   return (
     <div css={modalStyle}>
       <div css={headerStyle}>
-        <FiUser size={24}/>
+        <FiUser size={24} />
         <h2 css={titleStyle}>프로필 설정</h2>
       </div>
       <p css={subtitleStyle}>닉네임과 프로필 이미지를 변경할 수 있습니다.</p>
@@ -189,7 +202,7 @@ const ProfileSettingsModal = () => {
         profileImageUrl={previewImage}
       />
 
-      <hr css={hrStyle}/>
+      <hr css={hrStyle} />
 
       {/* 프로필 이미지 */}
       <ProfileImage
@@ -199,7 +212,7 @@ const ProfileSettingsModal = () => {
         disabled={saving}
       />
 
-      <hr css={hrStyle}/>
+      <hr css={hrStyle} />
 
       {/* 닉네임 */}
       <Nickname

--- a/src/components/modal/schedule_modal/scheduleModal.tsx
+++ b/src/components/modal/schedule_modal/scheduleModal.tsx
@@ -10,6 +10,7 @@ import ScheduleHeader from "./ScheduleHeader";
 import ScheduleCalendar from "./ScheduleCalendar";
 import { getLocalDateString } from "../../../utils/time";
 import { dummySchedules } from "../../../api/dummyData/schedule";
+import { toast } from "react-toastify";
 
 const ScheduleModal = () => {
   const [view, setView] = useState<ViewType>("list");
@@ -26,7 +27,7 @@ const ScheduleModal = () => {
     createSchedule,
     updateSchedule,
     deleteSchedule,
-    toggleComplete
+    toggleComplete,
   } = useSchedule();
 
   const { modalBackground } = useThemeColors();
@@ -65,7 +66,7 @@ const ScheduleModal = () => {
       const data = await getSchedules(dateStr);
       setSchedules(data);
     } catch (error) {
-      console.error("일정 로드 실패:", error);
+      toast.error(`일정 로드 실패:${error}`);
     } finally {
       setSchedules(dummySchedules);
       setLoading(false);
@@ -93,8 +94,7 @@ const ScheduleModal = () => {
       await deleteSchedule(scheduleId);
       setSchedules(schedules.filter((s) => s.id !== scheduleId));
     } catch (error) {
-      console.error("일정 삭제 실패:", error);
-      alert("일정 삭제에 실패했습니다.");
+      toast.error(`일정 삭제 실패:${error}`);
     } finally {
       setLoading(false);
     }
@@ -108,16 +108,13 @@ const ScheduleModal = () => {
       const newStatus = !currentStatus;
       // toggleComplete는 내부적으로 getScheduleById + updateSchedule 사용
       const updatedSchedule = await toggleComplete(scheduleId, newStatus);
-      
+
       // 반환된 Schedule로 상태 업데이트
       setSchedules(
-        schedules.map((s) =>
-          s.id === scheduleId ? updatedSchedule : s
-        )
+        schedules.map((s) => (s.id === scheduleId ? updatedSchedule : s))
       );
     } catch (error) {
-      console.error("일정 완료 토글 실패:", error);
-      alert("상태 변경에 실패했습니다.");
+      toast.error(`일정 완료 토글 실패:${error}`);
     }
   };
 
@@ -136,8 +133,7 @@ const ScheduleModal = () => {
       setView("list");
       setEditingSchedule(null);
     } catch (error) {
-      console.error("일정 저장 실패:", error);
-      alert("일정 저장에 실패했습니다.");
+      toast.error(`일정 저장 실패:${error}`);
     } finally {
       setLoading(false);
     }
@@ -171,7 +167,9 @@ const ScheduleModal = () => {
           ) : (
             <ScheduleForm
               schedule={editingSchedule}
-              selectedDate={selectedDate ? getLocalDateString(selectedDate) : ""}
+              selectedDate={
+                selectedDate ? getLocalDateString(selectedDate) : ""
+              }
               loading={loading}
               onSave={handleSave}
               onDelete={

--- a/src/components/sidebar/Leftbar/Leftbar.tsx
+++ b/src/components/sidebar/Leftbar/Leftbar.tsx
@@ -4,7 +4,6 @@ import { useThemeColors } from "../../../hooks/useThemeColors";
 import { flexCenter, sideBarSize, spaceBetween } from "../../../styles/mixins";
 import { GlassmorphismDesign } from "../../../styles/baseDesign/GlassmorphismDesign";
 import { css } from "@emotion/react";
-import { ThemeModeBtn } from "./ThemeModeBtn";
 import { Searchbar } from "./Searchbar";
 import { NewChat } from "./NewChatBtn";
 import { VoiceChat } from "./VoiceChat";
@@ -27,7 +26,7 @@ export function Leftbar() {
         <div css={[sideBarSize, sidebarColor]}>
           <div css={[flexCenter("row"), spaceBetween]}>
             <Logo />
-            <ThemeModeBtn />
+            <div className="ThemeModeBtn_space_empty_div"/>
           </div>
           <hr />
           <div css={[flexCenter("row", "0", "0.5rem")]}>

--- a/src/components/sidebar/Leftbar/ThemeModeBtn.tsx
+++ b/src/components/sidebar/Leftbar/ThemeModeBtn.tsx
@@ -15,29 +15,30 @@ export function ThemeModeBtn() {
   const { whereIsMouse } = useMousePositionStore();
 
   return (
-    <motion.div
-      initial={{
-        x:
-          whereIsMouse === "left"
-            ? SIDEBAR_MARGIN
-            : -SIDEBAR_WIDTH - SIDEBAR_MARGIN,
-      }}
-      animate={{
-        x:
-          whereIsMouse === "left"
-            ? SIDEBAR_MARGIN
-            : -SIDEBAR_WIDTH - SIDEBAR_MARGIN,
-      }}
-      transition={{ type: "spring", stiffness: 300, damping: 30 }}
-    >
-      <div css={positionCss} className="mode_btn">
+    <div css={positionCss} className="mode_btn">
+      <motion.div
+        initial={{
+          x:
+            whereIsMouse === "left"
+              ? SIDEBAR_MARGIN
+              : -SIDEBAR_WIDTH - SIDEBAR_MARGIN,
+        }}
+        animate={{
+          x:
+            whereIsMouse === "left"
+              ? SIDEBAR_MARGIN
+              : -SIDEBAR_WIDTH - SIDEBAR_MARGIN,
+        }}
+        transition={{ type: "spring", stiffness: 300, damping: 30 }}
+      >
         <ToggleBtn bool={mode === themeKeys[0]} toggle={toggle} />
-      </div>
-    </motion.div>
+      </motion.div>
+    </div>
   );
 }
 
 const positionCss = css`
-  position: absolute;
-
-`
+  position: fixed;
+  top: 20px;
+  left: 20px;
+`;

--- a/src/components/sidebar/Leftbar/ThemeModeBtn.tsx
+++ b/src/components/sidebar/Leftbar/ThemeModeBtn.tsx
@@ -39,6 +39,6 @@ export function ThemeModeBtn() {
 
 const positionCss = css`
   position: fixed;
-  top: 20px;
-  left: 20px;
+  top: 10rem;
+  left: 12rem;
 `;

--- a/src/components/sidebar/Leftbar/ThemeModeBtn.tsx
+++ b/src/components/sidebar/Leftbar/ThemeModeBtn.tsx
@@ -1,43 +1,43 @@
 /** @jsxImportSource @emotion/react */
-// import { css } from "@emotion/react";
+import { motion } from "framer-motion";
 import { storeColorMode } from "../../../store/storeColorMode";
 import { themeKeys } from "../../../styles/constColors";
 import { ToggleBtn } from "../../utilComponents/ToggleBtn";
-
-// export function ThemeModeBtn() {
-//   const { mode, toggle } = storeColorMode();
-//   const [bool, setBool] = useState(mode === themeKeys[0]);
-
-//   useEffect(() => {
-//   setBool(mode === themeKeys[0]);
-// }, [mode]);
-
-//   const handleToggle = () => {
-//     setBool((v) => !v);
-//     toggle();
-//   };
-
-//   return <ToggleBtn bool={bool} toggle={handleToggle} />;
-// }
+import {
+  SIDEBAR_MARGIN,
+  SIDEBAR_WIDTH,
+  useMousePositionStore,
+} from "../../../store/useMousePositionStore";
+import { css } from "@emotion/react";
 
 export function ThemeModeBtn() {
   const { mode, toggle } = storeColorMode();
+  const { whereIsMouse } = useMousePositionStore();
 
-  return <ToggleBtn bool={mode === themeKeys[0]} toggle={toggle} />;
+  return (
+    <motion.div
+      initial={{
+        x:
+          whereIsMouse === "left"
+            ? SIDEBAR_MARGIN
+            : -SIDEBAR_WIDTH - SIDEBAR_MARGIN,
+      }}
+      animate={{
+        x:
+          whereIsMouse === "left"
+            ? SIDEBAR_MARGIN
+            : -SIDEBAR_WIDTH - SIDEBAR_MARGIN,
+      }}
+      transition={{ type: "spring", stiffness: 300, damping: 30 }}
+    >
+      <div css={positionCss} className="mode_btn">
+        <ToggleBtn bool={mode === themeKeys[0]} toggle={toggle} />
+      </div>
+    </motion.div>
+  );
 }
 
-// const positionCss = css`
-//   position: absolute;
-//   top:1rem;
-//   right: 1rem;
-// `
+const positionCss = css`
+  position: absolute;
 
-// export function ThemeModeBtn() {
-//   const { isDark, toggle } = storeColorMode();
-
-//   return (
-//     <div css={positionCss}>
-//       <ToggleBtn bool={isDark} toggle={toggle} />
-//     </div>
-//   );
-// }
+`

--- a/src/components/sidebar/Rightbar/RightLogined.tsx
+++ b/src/components/sidebar/Rightbar/RightLogined.tsx
@@ -10,10 +10,13 @@ import { TodaySchedule } from "./TodaySchedule";
 import { BottomButtons } from "./BottomButtons";
 import { ProfileSettings } from "./ProfileSettings";
 import { useThemeColors } from "../../../hooks/useThemeColors";
-import {
-  sideBarMixin
-} from "../../../styles/mixins";
+import { flexCenter, itemMixin, scrollbarHidden, sideBarMixin } from "../../../styles/mixins";
 import { loginApi } from "../../../api/auth/login";
+import { FaClock } from "react-icons/fa";
+import DragAndDrop from "../../dragAndDrop/DragAndDrop";
+import { MdAccessTime } from "react-icons/md";
+import { formatTime } from "../../../utils/time";
+import { toast } from "react-toastify";
 
 const mocUser = {
   username: "user123",
@@ -35,7 +38,12 @@ export default function RightLogined({
 
   const [isProfileSettingOpen, setIsProfileSettingOpen] = useState(false);
 
-  const { modalBackground } = useThemeColors()
+  const {
+    modalBackground,
+    inputBorder,
+    tabBtnText,
+    scheduleTitleColor,
+  } = useThemeColors();
 
   const loginedContainerCss = css`
     display: flex;
@@ -45,59 +53,10 @@ export default function RightLogined({
   `;
   const hoverProfile = css`
     cursor: pointer;
-  `
+  `;
   const dividerCss = css`
     background: ${modalBackground};
     margin: 0;
-  `;
-
-
-  const menuSectionCss = css`
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-  `;
-
-  const menuItemCss = css`
-    display: flex;
-    width: 4rem;
-    gap: 0.25rem;
-    flex-direction: column;
-    align-items: center;
-    cursor: pointer;
-    padding: 0.5rem;
-    border-radius: 8px;
-    transition: background-color 0.2s;
-    position: relative;
-
-    &:hover {
-      background-color: rgba(255, 255, 255, 0.1);
-    }
-
-    span {
-      font-size: 0.8rem;
-      color: ${modalBackground};
-      font-weight: 500;
-    }
-  `;
-
-  const notificationCss = css`
-    position: relative;
-  `;
-
-  const notificationDotCss = css`
-    position: absolute;
-    top: 0.1rem;
-    right: 0.9rem;
-    width: 8px;
-    height: 8px;
-    background: ${deleteBtnBg};
-    border-radius: 50%;
-  `;
-
-  const iconCss = css`
-    font-size: 1.2rem;
-    color: ${modalBackground};
   `;
 
   const todayScheduleSectionCss = css`
@@ -160,106 +119,109 @@ export default function RightLogined({
     padding: 2rem 0;
   `;
 
-  const buttonSectionCss = css`
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-  `;
-
-  const crownIconCss = css`
-    font-size: 1rem;
-    color: ${crownIcon};
-  `;
-
   const goToPremium = () => {
     // 프리미엄 페이지로 이동
   };
 
-  // 일정관리 페이지로 이동
-  const handleSchedule = () => {
-    navigate("/modal/schedule", { 
-  state: { prevPath: location.pathname } 
-});
+  const handleRoute = (link: string) => {
+    navigate(`${link}`, {
+      state: { prevPath: location.pathname },
+    });
   };
 
-  const handleLogout = () => {
-    setIsLogin(false);
-    loginApi.DELETE.logout();
+  const handleLogout = async () => {
+    try {
+      const res = await loginApi.DELETE.logout();
+      setIsLogin(false);
+      toast.success(res.detail);
+    } catch (error) {
+      toast.error(`로그아웃 실패 : ${error}`);
+    }
   };
 
   return (
     <div css={[sideBarMixin]}>
-    <div css={loginedContainerCss}>
-      {/* 프로필 영역 (클릭 시 설정 모드 열림) */}
-      <div css={hoverProfile} onClick={() => setIsProfileSettingOpen(true)} >
-        <ProfileSection username={mocUser.username} email={mocUser.userEmail} />
-      </div>
-
-      <hr css={dividerCss} />
-
-      {isProfileSettingOpen ? (
-        // 프로필 설정 모드
-        <ProfileSettings 
-          onBack={() => setIsProfileSettingOpen(false)}
-          onChangeProfile={() => navigate("/modal/profilesetting")}
-          onChangePassword={() => navigate("/modal/password")} 
-          onDeleteAccount={() => navigate("/modal/deleteaccount")}/>
-      ) : (
-        // 기본 모드
-        <>
-          <MenuSection
-            unreadCount={unreadCount}
-            onScheduleClick={() => navigate("/modal/schedule")}
-            onNotificationClick={() => navigate("/modal/notification")}
+      <div css={loginedContainerCss}>
+        {/* 프로필 영역 (클릭 시 설정 모드 열림) */}
+        <div css={hoverProfile} onClick={() => setIsProfileSettingOpen(true)}>
+          <ProfileSection
+            username={mocUser.username}
+            email={mocUser.userEmail}
           />
-          <hr css={dividerCss} />
-
-          <TodaySchedule items={items} setItems={setItems} />
-          <hr css={dividerCss} />
-
-      {/* 오늘 일정 섹션 */}
-      <div css={todayScheduleSectionCss}>
-        <div css={todayScheduleHeaderCss}>
-          <FaClock css={clockIconCss} />
-          <span>오늘 일정 ({items.length})</span>
         </div>
 
-        <div css={[flexCenter(), scheduleContentCss]}>
-          {items.length === 0 ? (
-            <div css={emptyScheduleCss}>오늘 일정이 없습니다.</div>
-          ) : (
-            <DragAndDrop
-              items={items}
-              onItemsChange={setItems}
-              dragTitle={"title"}
-            >
-              {items.map((el) => {
-                return (
-                  <div key={el.id} css={itemMixin}>
-                    <div>
-                      <div
-                        css={[scheduleTitle, el.is_completed && completedTitle]}
-                      >
-                        {el.title}
-                      </div>
-                      <div css={scheduleTime}>
-                        <MdAccessTime />
-                        {formatTime(el.start_time)} ~ {formatTime(el.end_time)}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
-            </DragAndDrop>
-          )}
-        </div>
+        <hr css={dividerCss} />
+
+        {isProfileSettingOpen ? (
+          // 프로필 설정 모드
+          <ProfileSettings
+            onBack={() => setIsProfileSettingOpen(false)}
+            onChangeProfile={() => navigate("/modal/profilesetting")}
+            onChangePassword={() => navigate("/modal/password")}
+            onDeleteAccount={() => handleRoute("/modal/deleteaccount")}
+          />
+        ) : (
+          // 기본 모드
+          <>
+            <MenuSection
+              unreadCount={unreadCount}
+              onScheduleClick={() => handleRoute("/modal/schedule")}
+              onNotificationClick={() => handleRoute("/modal/notification")}
+            />
+            <hr css={dividerCss} />
+
+            <TodaySchedule items={items} setItems={setItems} />
+            <hr css={dividerCss} />
+
+            {/* 오늘 일정 섹션 */}
+            <div css={todayScheduleSectionCss}>
+              <div css={todayScheduleHeaderCss}>
+                <FaClock css={clockIconCss} />
+                <span>오늘 일정 ({items.length})</span>
+              </div>
+
+              <div css={[flexCenter(), scheduleContentCss]}>
+                {items.length === 0 ? (
+                  <div css={emptyScheduleCss}>오늘 일정이 없습니다.</div>
+                ) : (
+                  <DragAndDrop
+                    items={items}
+                    onItemsChange={setItems}
+                    dragTitle={"title"}
+                  >
+                    {items.map((el) => {
+                      return (
+                        <div key={el.id} css={itemMixin}>
+                          <div>
+                            <div
+                              css={[
+                                scheduleTitle,
+                                el.is_completed && completedTitle,
+                              ]}
+                            >
+                              {el.title}
+                            </div>
+                            <div css={scheduleTime}>
+                              <MdAccessTime />
+                              {formatTime(el.start_time)} ~{" "}
+                              {formatTime(el.end_time)}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </DragAndDrop>
+                )}
+              </div>
+            </div>
+
+            <hr css={dividerCss} />
+
+            {/* 하단 버튼들 */}
+            <BottomButtons onLogout={handleLogout} onPremium={goToPremium} />
+          </>
+        )}
       </div>
-
-      <hr css={dividerCss} />
-
-      {/* 하단 버튼들 */}
-      <BottomButtons onLogout={handleLogout} onPremium={goToPremium}/>
-      
     </div>
   );
 }

--- a/src/components/utilComponents/GetNotiTypes.tsx
+++ b/src/components/utilComponents/GetNotiTypes.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { apiNoti } from "../../api/notification/notification";
+import { storeNotiTypes } from "../../store/storeNotiTypes";
+import { toast } from "react-toastify";
+
+export function NotiTypesSetter() {
+  const { setNotiTypes } = storeNotiTypes();
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await apiNoti.GET.types();
+        setNotiTypes(res);
+      } catch (error) {
+        toast.error(`알림 타입 불러오기 실패:${error}`)
+      }
+    })();
+  }, []);
+  return null;
+}

--- a/src/components/utilComponents/WindowSizeProvider.tsx
+++ b/src/components/utilComponents/WindowSizeProvider.tsx
@@ -8,7 +8,7 @@ const MOBILE_THRESHOLD = 640;
  * 브라우저 너비 계산 및 저장용 기능성 컴포넌트
  * @returns {null}
  */
-export default function WindowSizeProvider() {
+export default function WindowSizeSetter() {
   const setWindowWidth = useWindowWidthStore((s) => s.setWindowWidth);
   const setPlatform = useDeviceTypeStore((s) => s.setPlatform);
 

--- a/src/hooks/api/useProfile.ts
+++ b/src/hooks/api/useProfile.ts
@@ -1,4 +1,4 @@
-import { profileApi } from '../../api/auth/profile';
+import { apiProfile } from '../../api/auth/profile';
 import type { GetProfileRes, PutProfileReq, PutProfileRes } from '../../api/auth/profile';
 
 export const useProfile = () => {
@@ -7,7 +7,7 @@ export const useProfile = () => {
    */
   const getProfile = async (): Promise<GetProfileRes> => {
     // console.log('useProfile.getProfile 호출');
-    return await profileApi.GET.profile();
+    return await apiProfile.GET.profile();
   };
 
   /**
@@ -22,7 +22,7 @@ export const useProfile = () => {
       throw new Error('수정할 내용이 없습니다.');
     }
     
-    return await profileApi.PUT.profile(data);
+    return await apiProfile.PUT.profile(data);
   };
 
   /**
@@ -31,7 +31,7 @@ export const useProfile = () => {
    */
   const updateProfileImage = async (imageUrl: string | null): Promise<PutProfileRes> => {
     // console.log('useProfile.updateProfileImage 호출:', imageUrl);
-    return await profileApi.PUT.profile({ profile_image_url: imageUrl });
+    return await apiProfile.PUT.profile({ profile_image_url: imageUrl });
   };
 
   /**
@@ -45,7 +45,7 @@ export const useProfile = () => {
       throw new Error('닉네임을 입력해주세요.');
     }
     
-    return await profileApi.PUT.profile({ nickname: nickname.trim() });
+    return await apiProfile.PUT.profile({ nickname: nickname.trim() });
   };
 
   return {

--- a/src/hooks/api/useProfile.ts
+++ b/src/hooks/api/useProfile.ts
@@ -6,7 +6,7 @@ export const useProfile = () => {
    * 프로필 조회
    */
   const getProfile = async (): Promise<GetProfileRes> => {
-    console.log('useProfile.getProfile 호출');
+    // console.log('useProfile.getProfile 호출');
     return await profileApi.GET.profile();
   };
 
@@ -15,7 +15,7 @@ export const useProfile = () => {
    * @param data 수정할 필드 (nickname, profile_image_url)
    */
   const updateProfile = async (data: PutProfileReq): Promise<PutProfileRes> => {
-    console.log('useProfile.updateProfile 호출:', data);
+    // console.log('useProfile.updateProfile 호출:', data);
     
     // 수정할 내용이 없으면 에러
     if (!data.nickname && !data.profile_image_url && data.profile_image_url !== null) {
@@ -30,7 +30,7 @@ export const useProfile = () => {
    * @param imageUrl 이미지 URL (null이면 이미지 삭제)
    */
   const updateProfileImage = async (imageUrl: string | null): Promise<PutProfileRes> => {
-    console.log('useProfile.updateProfileImage 호출:', imageUrl);
+    // console.log('useProfile.updateProfileImage 호출:', imageUrl);
     return await profileApi.PUT.profile({ profile_image_url: imageUrl });
   };
 
@@ -39,7 +39,7 @@ export const useProfile = () => {
    * @param nickname 새 닉네임
    */
   const updateNickname = async (nickname: string): Promise<PutProfileRes> => {
-    console.log('useProfile.updateNickname 호출:', nickname);
+    // console.log('useProfile.updateNickname 호출:', nickname);
     
     if (!nickname || nickname.trim() === '') {
       throw new Error('닉네임을 입력해주세요.');

--- a/src/hooks/api/useSchedule.ts
+++ b/src/hooks/api/useSchedule.ts
@@ -61,7 +61,7 @@ export const useSchedule = () => {
   };
 
   // 완료 상태 토글 (PUT을 활용)
-  const toggleComplete = async (id: number, completed: boolean): Promise<Schedule> => {
+  const toggleComplete = async (id: number, isCompleted: boolean): Promise<Schedule> => {
     // 1. 기존 일정 정보 조회
     const schedule = await scheduleAPI.GET.scheduleById(id);
     
@@ -71,7 +71,7 @@ export const useSchedule = () => {
       description: schedule.description || '',
       start_time: schedule.start_time,
       end_time: schedule.end_time,
-      is_completed: completed
+      is_completed: isCompleted
     };
     return await scheduleAPI.PUT.scheduleById(id, request);
   };

--- a/src/store/storeNotiTypes.ts
+++ b/src/store/storeNotiTypes.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+import type { NotificationType } from "../api/notification/notification";
+
+type NotiType = {
+  id: number;
+  code: string;
+};
+
+interface storeNotiTypes {
+  notiTypes: NotiType[];
+  setNotiTypes: (val: NotificationType[]) => void;
+}
+
+export const storeNotiTypes = create<storeNotiTypes>((set) => ({
+  notiTypes: [],
+  setNotiTypes: (val) =>
+    set(() => ({ notiTypes: val.map(({ id, code }) => ({ id, code })) })),
+}));

--- a/src/store/storeUserEmail.ts
+++ b/src/store/storeUserEmail.ts
@@ -1,0 +1,10 @@
+import { create } from "zustand";
+
+interface storeUserEmail {
+  userEmail: string;
+  setUserEmail: (val: string) => void;
+}
+export const storeUserEmail = create<storeUserEmail>((set) => ({
+  userEmail: "",
+  setUserEmail: (val) => set(() => ({ userEmail: val })),
+}));

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -22,9 +22,9 @@ export const formatTime = (isoString: string): string => {
   const date = new Date(isoString);
   const pad = (n: number) => String(n).padStart(2, '0');
   
-  console.log('ISO 문자열:', isoString);
-  console.log('Date 객체:', date);
-  console.log('getHours:', date.getHours(), 'getMinutes:', date.getMinutes());
+  // console.log('ISO 문자열:', isoString);
+  // console.log('Date 객체:', date);
+  // console.log('getHours:', date.getHours(), 'getMinutes:', date.getMinutes());
 
   return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
 };

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -28,3 +28,15 @@ export const formatTime = (isoString: string): string => {
 
   return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
 };
+
+// 알림 "~~ 분 전" 포맷팅용 함수
+export const formatRelativeTime = (isoDate: string): string => {
+  const now = new Date();
+  const target = new Date(isoDate);
+  const diff = Math.floor((now.getTime() - target.getTime()) / 1000);
+
+  if (diff < 60) return `${diff}초 전`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
+  return `${Math.floor(diff / 86400)}일 전`;
+};


### PR DESCRIPTION
알림 타입, api 콜 부분 구조 개선
기존 mapNotification 의 경우 모든 키값을 다른 이름으로 따로 받아 불필요한 중복이 있었음
백엔드 res 기준으로 통일해 최대한 간결히 줄임
기존에 컴포넌트 내부 api 콜들 res를 통해 응답 메시지를 받지 않았으나, 이를 활용하도록 변경함
전체 읽음 처리가 하나만 실패해도 요청이 모두 끊기는 Promise.all을 사용하고, 실패/성공 구분 없이 성공 후 무조건 상태를 읽음 상태로 변경하는 문제가 있었음
Promise.allSettled로 중간에 실패 나와도 처리 시도하도록 변경함
zip+reduce로 성공, 실패를 나누어 각각 처리하도록 시도함
실패시 유저에겐 title을 toast로, 디버깅엔 id를 console로 표시하도록 변경

다크/화이트 모드버튼이 배경의 자식으로 포함되어 있어 리랜더링 이슈가 존재했음
백그라운드 외부로 방출해 독립적으로 동작하도록 변경함

기존의 alert는 보안상, 성능상의 이슈로 전부 삭제함
console.error또한 불필요하게 많아 대부분 변경
alert, 
console.error 모두 toast로 대체함

ProfileSettingsModal에서 실제 api 요청을 보내도록 변경

기존의 유틸 컴포넌트들(useEffect를 활용해 상태를 변경하는 기능성 메서드들) 이름이 provider, setter, get 등 다양한 이름이 있었으나 setter로 통일함